### PR TITLE
feat: 공연 어드민 홈 마크업 추가

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -39,8 +39,6 @@ const router = createBrowserRouter([
 ]);
 
 const App = () => {
-  // const { data } = useHelloQuery();
-  // console.log(data?.hello)
   return (
     <QueryClientProvider>
       <BooltiUIProvider>

--- a/apps/admin/src/components/AccountInfo/AccountInfo.styles.ts
+++ b/apps/admin/src/components/AccountInfo/AccountInfo.styles.ts
@@ -1,0 +1,45 @@
+import styled from '@emotion/styled';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  justify-content: center;
+  border-radius: 8px;
+  background-color: ${({ theme }) => theme.palette.grey.g10};
+  padding: 28px 32px;
+`;
+
+const Title = styled.p`
+  ${({ theme }) => theme.typo.h1};
+  color: ${({ theme }) => theme.palette.grey.g90};
+  margin-bottom: 4px;
+`;
+
+const Description = styled.span`
+  ${({ theme }) => theme.typo.b3};
+  color: ${({ theme }) => theme.palette.grey.g70};
+  margin-bottom: 24px;
+`;
+
+const AccountText = styled.span`
+  ${({ theme }) => theme.typo.sh2};
+  color: ${({ theme }) => theme.palette.grey.g90};
+  margin-right: 8px;
+  &:last-of-type {
+    margin-right: 16px;
+  }
+`;
+
+const AccountContainer = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+export default {
+  Container,
+  Title,
+  Description,
+  AccountText,
+  AccountContainer,
+};

--- a/apps/admin/src/components/AccountInfo/index.tsx
+++ b/apps/admin/src/components/AccountInfo/index.tsx
@@ -1,0 +1,27 @@
+import { Button } from '@boolti/ui';
+import Styled from './AccountInfo.styles';
+
+interface Props {
+  orgName?: string;
+  accountNumber?: string;
+  accountHolder?: string;
+}
+
+const AccountInfo = ({ orgName, accountHolder, accountNumber }: Props) => {
+  return (
+    <Styled.Container>
+      <Styled.Title>정산 계좌 정보</Styled.Title>
+      <Styled.Description>빠른 정산을 위해서는 정확한 계좌 정보가 필요해요.</Styled.Description>
+      <Styled.AccountContainer>
+        {orgName && <Styled.AccountText>{orgName}</Styled.AccountText>}
+        {accountNumber && <Styled.AccountText>{accountNumber}</Styled.AccountText>}
+        {accountHolder && <Styled.AccountText>{accountHolder}</Styled.AccountText>}
+        <Button type="button" colorTheme="netural" size="regular">
+          {accountNumber ? '변경하기' : '입력하기'}
+        </Button>
+      </Styled.AccountContainer>
+    </Styled.Container>
+  );
+};
+
+export default AccountInfo;

--- a/apps/admin/src/components/Layout/Layout.styles.ts
+++ b/apps/admin/src/components/Layout/Layout.styles.ts
@@ -10,7 +10,7 @@ const HeaderContainer = styled.div`
 `;
 
 const Header = styled.header`
-  width: ${({ theme }) => theme.breakpoint.desktop};
+  max-width: ${({ theme }) => theme.breakpoint.desktop};
   margin: 0 auto;
   padding: 0 20px;
 `;

--- a/apps/admin/src/components/ShowList/ShowList.styles.ts
+++ b/apps/admin/src/components/ShowList/ShowList.styles.ts
@@ -1,0 +1,41 @@
+import styled from '@emotion/styled';
+
+const Container = styled.div``;
+
+const List = styled.ol`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  min-height: 240px;
+  border: 1px solid ${({ theme }) => theme.palette.grey.g20};
+  background-color: ${({ theme }) => theme.palette.grey.w};
+  box-shadow: 0px 8px 14px 0px rgba(136, 141, 157, 0.15);
+  padding: 28px 32px;
+`;
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+`;
+
+const HeaderText = styled.h2`
+  ${({ theme }) => theme.typo.h2};
+  color: ${({ theme }) => theme.palette.grey.g90};
+`;
+
+const EmptyText = styled.p`
+  ${({ theme }) => theme.typo.b4};
+  color: ${({ theme }) => theme.palette.grey.g40};
+`;
+
+export default {
+  Container,
+  List,
+  Header,
+  EmptyText,
+  HeaderText,
+};

--- a/apps/admin/src/components/ShowList/ShowList.styles.ts
+++ b/apps/admin/src/components/ShowList/ShowList.styles.ts
@@ -3,16 +3,7 @@ import styled from '@emotion/styled';
 const Container = styled.div``;
 
 const List = styled.ol`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  border-radius: 8px;
-  min-height: 240px;
-  border: 1px solid ${({ theme }) => theme.palette.grey.g20};
-  background-color: ${({ theme }) => theme.palette.grey.w};
-  box-shadow: 0px 8px 14px 0px rgba(136, 141, 157, 0.15);
-  padding: 28px 32px;
+  list-style: none;
 `;
 
 const Header = styled.div`
@@ -27,15 +18,9 @@ const HeaderText = styled.h2`
   color: ${({ theme }) => theme.palette.grey.g90};
 `;
 
-const EmptyText = styled.p`
-  ${({ theme }) => theme.typo.b4};
-  color: ${({ theme }) => theme.palette.grey.g40};
-`;
-
 export default {
   Container,
   List,
   Header,
-  EmptyText,
   HeaderText,
 };

--- a/apps/admin/src/components/ShowList/index.tsx
+++ b/apps/admin/src/components/ShowList/index.tsx
@@ -1,0 +1,26 @@
+import { Button } from '@boolti/ui';
+import Styled from './ShowList.styles';
+import { PlusIcon } from '@boolti/icon';
+
+interface Props {
+  shows: unknown[];
+}
+
+const ShowList = ({ shows }: Props) => {
+  const isEmpty = shows.length === 0;
+  return (
+    <Styled.Container>
+      <Styled.Header>
+        <Styled.HeaderText>등록한 공연</Styled.HeaderText>
+        <Button type="button" colorTheme="primary" size="bold" icon={<PlusIcon size={20} />}>
+          공연 등록하기
+        </Button>
+      </Styled.Header>
+      <Styled.List>
+        {isEmpty && <Styled.EmptyText>아직 등록한 공연이 없어요.</Styled.EmptyText>}
+      </Styled.List>
+    </Styled.Container>
+  );
+};
+
+export default ShowList;

--- a/apps/admin/src/components/ShowList/index.tsx
+++ b/apps/admin/src/components/ShowList/index.tsx
@@ -18,7 +18,7 @@ const ShowList = ({ shows }: Props) => {
         </Button>
       </Styled.Header>
       {isEmpty ? (
-        <ShowListItem isEmpty />
+        <ShowListItem isEmpty thumbnailPath="" title="" date="" host="" />
       ) : (
         <Styled.List>
           {shows.map((show, index) => (

--- a/apps/admin/src/components/ShowList/index.tsx
+++ b/apps/admin/src/components/ShowList/index.tsx
@@ -1,9 +1,10 @@
 import { Button } from '@boolti/ui';
 import Styled from './ShowList.styles';
 import { PlusIcon } from '@boolti/icon';
+import ShowListItem from '../ShowListItem';
 
 interface Props {
-  shows: unknown[];
+  shows: React.ComponentProps<typeof ShowListItem>[];
 }
 
 const ShowList = ({ shows }: Props) => {
@@ -16,9 +17,15 @@ const ShowList = ({ shows }: Props) => {
           공연 등록하기
         </Button>
       </Styled.Header>
-      <Styled.List>
-        {isEmpty && <Styled.EmptyText>아직 등록한 공연이 없어요.</Styled.EmptyText>}
-      </Styled.List>
+      {isEmpty ? (
+        <ShowListItem isEmpty />
+      ) : (
+        <Styled.List>
+          {shows.map((show, index) => (
+            <ShowListItem key={index} {...show} />
+          ))}
+        </Styled.List>
+      )}
     </Styled.Container>
   );
 };

--- a/apps/admin/src/components/ShowListItem/ShowListItem.styles.ts
+++ b/apps/admin/src/components/ShowListItem/ShowListItem.styles.ts
@@ -1,0 +1,24 @@
+import styled from '@emotion/styled';
+
+const Container = styled.li`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  min-height: 240px;
+  border: 1px solid ${({ theme }) => theme.palette.grey.g20};
+  background-color: ${({ theme }) => theme.palette.grey.w};
+  box-shadow: 0px 8px 14px 0px rgba(136, 141, 157, 0.15);
+  padding: 28px 32px;
+`;
+
+const EmptyText = styled.p`
+  ${({ theme }) => theme.typo.b4};
+  color: ${({ theme }) => theme.palette.grey.g40};
+`;
+
+export default {
+  Container,
+  EmptyText,
+};

--- a/apps/admin/src/components/ShowListItem/ShowListItem.styles.ts
+++ b/apps/admin/src/components/ShowListItem/ShowListItem.styles.ts
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 
 const Container = styled.li`
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
   border-radius: 8px;
@@ -11,6 +10,17 @@ const Container = styled.li`
   background-color: ${({ theme }) => theme.palette.grey.w};
   box-shadow: 0px 8px 14px 0px rgba(136, 141, 157, 0.15);
   padding: 28px 32px;
+  &:not(:last-of-type) {
+    margin-bottom: 24px;
+  }
+`;
+
+const Button = styled.button`
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
 `;
 
 const EmptyText = styled.p`
@@ -18,7 +28,70 @@ const EmptyText = styled.p`
   color: ${({ theme }) => theme.palette.grey.g40};
 `;
 
+const Poster = styled.div<{ thumbnailPath: string }>`
+  width: 130px;
+  height: 184px;
+  border: 1px solid ${({ theme }) => theme.palette.grey.g20};
+  background-image: url(${({ thumbnailPath }) => thumbnailPath});
+  background-position: center;
+  margin-right: 28px;
+  border-radius: 6px;
+`;
+
+const TextContainer = styled.div`
+  flex: 1;
+  height: 184px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+const Title = styled.h2`
+  margin-right: 8px;
+  ${({ theme }) => theme.typo.h2_m};
+  color: ${({ theme }) => theme.palette.grey.g90};
+`;
+
+const TitleContainer = styled.div`
+  display: flex;
+`;
+
+const InfoContainer = styled.div``;
+
+const InfoColumn = styled.div`
+  &:not(:last-of-type) {
+    margin-bottom: 4px;
+  }
+`;
+
+const InfoText = styled.span<{ isLabel?: boolean }>`
+  display: inline-block;
+  min-width: 92px;
+  margin-right: 16px;
+  ${({ theme }) => theme.typo.b3};
+  color: ${({ isLabel, theme }) => (isLabel ? theme.palette.grey.g60 : theme.palette.grey.g90)};
+`;
+
+const IconContainer = styled.div`
+  width: 36px;
+  height: 36px;
+  color: ${({ theme }) => theme.palette.grey.g60};
+  & > svg {
+    width: 36px;
+    height: 36px;
+  }
+`;
+
 export default {
   Container,
   EmptyText,
+  Poster,
+  Button,
+  TextContainer,
+  Title,
+  InfoContainer,
+  InfoColumn,
+  InfoText,
+  IconContainer,
+  TitleContainer,
 };

--- a/apps/admin/src/components/ShowListItem/index.tsx
+++ b/apps/admin/src/components/ShowListItem/index.tsx
@@ -1,13 +1,50 @@
+import { Badge } from '@boolti/ui';
 import Styled from './ShowListItem.styles';
+import { ChevronRightIcon } from '@boolti/icon';
 
 interface Props {
   isEmpty?: boolean;
+  thumbnailPath: string;
+  title: string;
+  date: string;
+  host: string;
 }
 
-const ShowListItem = ({ isEmpty }: Props) => {
+const ShowListItem = ({ isEmpty, thumbnailPath, title, date, host }: Props) => {
   return (
     <Styled.Container as={isEmpty ? 'div' : 'li'}>
-      {isEmpty && <Styled.EmptyText>아직 등록한 공연이 없어요.</Styled.EmptyText>}
+      {isEmpty ? (
+        <Styled.EmptyText>아직 등록한 공연이 없어요.</Styled.EmptyText>
+      ) : (
+        <Styled.Button>
+          <Styled.Poster thumbnailPath={thumbnailPath} />
+          <Styled.TextContainer>
+            <Styled.TitleContainer>
+              <Styled.Title>{title}</Styled.Title>
+              <Badge colorTheme="red">공연 당일</Badge>
+            </Styled.TitleContainer>
+            <Styled.InfoContainer>
+              <Styled.InfoColumn>
+                <Styled.InfoText isLabel>호스트</Styled.InfoText>
+                <Styled.InfoText>{host}</Styled.InfoText>
+              </Styled.InfoColumn>
+              <Styled.InfoColumn>
+                <Styled.InfoText isLabel>공연일시</Styled.InfoText>
+                <Styled.InfoText>{date}</Styled.InfoText>
+              </Styled.InfoColumn>
+              <Styled.InfoColumn>
+                <Styled.InfoText isLabel>티켓 판매 기간</Styled.InfoText>
+                <Styled.InfoText>
+                  {date} ~ {date}
+                </Styled.InfoText>
+              </Styled.InfoColumn>
+            </Styled.InfoContainer>
+          </Styled.TextContainer>
+          <Styled.IconContainer>
+            <ChevronRightIcon size={24} />
+          </Styled.IconContainer>
+        </Styled.Button>
+      )}
     </Styled.Container>
   );
 };

--- a/apps/admin/src/components/ShowListItem/index.tsx
+++ b/apps/admin/src/components/ShowListItem/index.tsx
@@ -1,0 +1,15 @@
+import Styled from './ShowListItem.styles';
+
+interface Props {
+  isEmpty?: boolean;
+}
+
+const ShowListItem = ({ isEmpty }: Props) => {
+  return (
+    <Styled.Container as={isEmpty ? 'div' : 'li'}>
+      {isEmpty && <Styled.EmptyText>아직 등록한 공연이 없어요.</Styled.EmptyText>}
+    </Styled.Container>
+  );
+};
+
+export default ShowListItem;

--- a/apps/admin/src/components/UserProfile/UserProfile.styles.ts
+++ b/apps/admin/src/components/UserProfile/UserProfile.styles.ts
@@ -1,0 +1,34 @@
+import styled from '@emotion/styled';
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const ProfileImage = styled.img`
+  border-radius: 100%;
+  background-color: ${({ theme }) => theme.palette.grey.g90};
+`;
+
+const TextContainer = styled.div`
+  margin-left: 16px;
+`;
+
+const Username = styled.p`
+  ${({ theme }) => theme.typo.sh2};
+  color: ${({ theme }) => theme.palette.grey.g90};
+  margin-bottom: 6px;
+`;
+
+const Email = styled.span`
+  ${({ theme }) => theme.typo.b3};
+  color: ${({ theme }) => theme.palette.grey.g70};
+`;
+
+export default {
+  Container,
+  ProfileImage,
+  TextContainer,
+  Username,
+  Email,
+};

--- a/apps/admin/src/components/UserProfile/index.tsx
+++ b/apps/admin/src/components/UserProfile/index.tsx
@@ -1,0 +1,21 @@
+import Styled from './UserProfile.styles';
+
+interface Props {
+  profileImage: string;
+  username: string;
+  email: string;
+}
+
+const UserProfile = ({ profileImage, username, email }: Props) => {
+  return (
+    <Styled.Container>
+      <Styled.ProfileImage width={68} height={68} alt="" src={profileImage} />
+      <Styled.TextContainer>
+        <Styled.Username>{username}</Styled.Username>
+        <Styled.Email>{email}</Styled.Email>
+      </Styled.TextContainer>
+    </Styled.Container>
+  );
+};
+
+export default UserProfile;

--- a/apps/admin/src/pages/HomePage/HomePage.styles.ts
+++ b/apps/admin/src/pages/HomePage/HomePage.styles.ts
@@ -19,10 +19,13 @@ const LogoutLink = styled(Link)`
   color: ${({ theme }) => theme.palette.grey.g90};
 `;
 
-const HomePage = styled.div``;
+const Container = styled.main`
+  min-height: calc(100vh - 68px - 274px);
+  padding-top: 60px;
+`;
 
 export default {
   Logo,
   LogoutLink,
-  HomePage,
+  Container,
 };

--- a/apps/admin/src/pages/HomePage/HomePage.styles.ts
+++ b/apps/admin/src/pages/HomePage/HomePage.styles.ts
@@ -21,7 +21,7 @@ const LogoutLink = styled(Link)`
 
 const Container = styled.main`
   min-height: calc(100vh - 68px - 274px);
-  padding-top: 60px;
+  padding: 60px 20px 0;
 `;
 
 export default {

--- a/apps/admin/src/pages/HomePage/HomePage.styles.ts
+++ b/apps/admin/src/pages/HomePage/HomePage.styles.ts
@@ -19,6 +19,10 @@ const LogoutLink = styled(Link)`
   color: ${({ theme }) => theme.palette.grey.g90};
 `;
 
+const Seperator = styled.hr<{ size: number }>`
+  height: ${({ size }) => size}px;
+`;
+
 const Container = styled.main`
   min-height: calc(100vh - 68px - 274px);
   padding: 60px 20px 0;
@@ -28,4 +32,5 @@ export default {
   Logo,
   LogoutLink,
   Container,
+  Seperator,
 };

--- a/apps/admin/src/pages/HomePage/HomePage.tsx
+++ b/apps/admin/src/pages/HomePage/HomePage.tsx
@@ -4,6 +4,7 @@ import { PATH } from '~/constants/routes';
 import Styled from './HomePage.styles';
 import { Footer } from '@boolti/ui';
 import UserProfile from '~/components/UserProfile';
+import AccountInfo from '~/components/AccountInfo';
 
 const HomePage = () => {
   return (
@@ -21,6 +22,9 @@ const HomePage = () => {
           username="%사용자명%"
           email="Boolti@boolti.io"
         />
+        <Styled.Seperator size={40} />
+        <AccountInfo accountHolder="김불티" accountNumber="000000000000" orgName="토스뱅크" />
+        <Styled.Seperator size={80} />
       </Styled.Container>
       <Footer />
     </Layout>

--- a/apps/admin/src/pages/HomePage/HomePage.tsx
+++ b/apps/admin/src/pages/HomePage/HomePage.tsx
@@ -26,7 +26,22 @@ const HomePage = () => {
         <Styled.Seperator size={40} />
         <AccountInfo accountHolder="김불티" accountNumber="000000000000" orgName="토스뱅크" />
         <Styled.Seperator size={80} />
-        <ShowList shows={[]} />
+        <ShowList
+          shows={[
+            {
+              thumbnailPath: 'https://picsum.photos/200',
+              title: 'Show Title',
+              date: '2024-01-20',
+              host: '%사용자명%',
+            },
+            {
+              thumbnailPath: 'https://picsum.photos/200',
+              title: 'Show Title2',
+              date: '2024-01-21',
+              host: '%사용자명%',
+            },
+          ]}
+        />
         <Styled.Seperator size={80} />
       </Styled.Container>
       <Footer />

--- a/apps/admin/src/pages/HomePage/HomePage.tsx
+++ b/apps/admin/src/pages/HomePage/HomePage.tsx
@@ -5,6 +5,7 @@ import Styled from './HomePage.styles';
 import { Footer } from '@boolti/ui';
 import UserProfile from '~/components/UserProfile';
 import AccountInfo from '~/components/AccountInfo';
+import ShowList from '~/components/ShowList';
 
 const HomePage = () => {
   return (
@@ -24,6 +25,8 @@ const HomePage = () => {
         />
         <Styled.Seperator size={40} />
         <AccountInfo accountHolder="김불티" accountNumber="000000000000" orgName="토스뱅크" />
+        <Styled.Seperator size={80} />
+        <ShowList shows={[]} />
         <Styled.Seperator size={80} />
       </Styled.Container>
       <Footer />

--- a/apps/admin/src/pages/HomePage/HomePage.tsx
+++ b/apps/admin/src/pages/HomePage/HomePage.tsx
@@ -1,18 +1,9 @@
-import { useToast, useDialog, useConfirm } from '@boolti/ui';
-import Header from '../../components/Header/Header';
-import Layout from '../../components/Layout/Layout';
-import { PATH } from '../../constants/routes';
+import Header from '~/components/Header/Header';
+import Layout from '~/components/Layout/Layout';
+import { PATH } from '~/constants/routes';
 import Styled from './HomePage.styles';
 
 const HomePage = () => {
-  const toast = useToast();
-
-  const dialog1 = useDialog();
-  const dialog2 = useDialog();
-  const dialog3 = useDialog();
-
-  const confirm = useConfirm();
-
   return (
     <Layout
       header={
@@ -22,122 +13,7 @@ const HomePage = () => {
         />
       }
     >
-      <h2>HomePage</h2>
-      <div>
-        <button
-          onClick={() => {
-            toast.success('성공했을 때 메세지입니다.');
-          }}
-        >
-          성공 토스트 띄우기
-        </button>
-      </div>
-      <div>
-        <button
-          onClick={() => {
-            toast.warning('경고 메세지입니다.');
-          }}
-        >
-          경고 토스트 띄우기
-        </button>
-      </div>
-      <div>
-        <button
-          onClick={() => {
-            toast.error('에러 메세지입니다.');
-          }}
-        >
-          에러 토스트 띄우기
-        </button>
-      </div>
-      <div>
-        <button
-          onClick={() => {
-            toast.info('정보제공 메세지입니다.');
-          }}
-        >
-          정보 제공 토스트 띄우기
-        </button>
-      </div>
-      <button
-        onClick={() => {
-          dialog1.open({
-            title: '다이얼로그 1 ',
-            content: (
-              <button
-                onClick={() => {
-                  dialog3.open({
-                    title: '다이얼로그 안의 다이얼로그',
-                    content: (
-                      <p>
-                        다이얼로그 내용
-                        <br />
-                        다이얼로그 ID : {dialog3.id}
-                      </p>
-                    ),
-                    onClose: () => {
-                      console.log('다이얼로그 안의 다이얼로그 닫힘');
-                    },
-                  });
-                }}
-              >
-                다이얼로그 안의 다이얼로그 열기
-                <br />
-                다이얼로그 ID : {dialog1.id}
-              </button>
-            ),
-            onClose: () => {
-              console.log('다이얼로그 1 닫힘');
-            },
-          });
-        }}
-      >
-        Open Dialog 1
-      </button>
-
-      <button
-        onClick={() => {
-          dialog2.open({
-            title: '다이얼로그 2',
-            content: (
-              <p>
-                다이얼로그 내용
-                <br />
-                다이얼로그 ID : {dialog2.id}
-              </p>
-            ),
-            onClose: () => {
-              console.log('다이얼로그 2 닫힘');
-            },
-          });
-        }}
-      >
-        Open Dialog 2
-      </button>
-
-      <button
-        onClick={async () => {
-          const result = await confirm(
-            <>
-              지금 로그아웃하면 작성 중인 내용이 사라져요.
-              <br />
-              로그아웃 할까요?
-            </>,
-            {
-              cancel: '취소하기',
-              confirm: '로그아웃',
-            },
-          );
-
-          if (result) {
-            alert('로그아웃');
-          } else {
-            alert('로그아웃 취소');
-          }
-        }}
-      >
-        Open confirm
-      </button>
+      <h2>HOME</h2>
     </Layout>
   );
 };

--- a/apps/admin/src/pages/HomePage/HomePage.tsx
+++ b/apps/admin/src/pages/HomePage/HomePage.tsx
@@ -3,6 +3,7 @@ import Layout from '~/components/Layout/Layout';
 import { PATH } from '~/constants/routes';
 import Styled from './HomePage.styles';
 import { Footer } from '@boolti/ui';
+import UserProfile from '~/components/UserProfile';
 
 const HomePage = () => {
   return (
@@ -14,7 +15,13 @@ const HomePage = () => {
         />
       }
     >
-      <Styled.Container></Styled.Container>
+      <Styled.Container>
+        <UserProfile
+          profileImage="https://picsum.photos/200"
+          username="%사용자명%"
+          email="Boolti@boolti.io"
+        />
+      </Styled.Container>
       <Footer />
     </Layout>
   );

--- a/apps/admin/src/pages/HomePage/HomePage.tsx
+++ b/apps/admin/src/pages/HomePage/HomePage.tsx
@@ -2,6 +2,7 @@ import Header from '~/components/Header/Header';
 import Layout from '~/components/Layout/Layout';
 import { PATH } from '~/constants/routes';
 import Styled from './HomePage.styles';
+import { Footer } from '@boolti/ui';
 
 const HomePage = () => {
   return (
@@ -13,7 +14,8 @@ const HomePage = () => {
         />
       }
     >
-      <h2>HOME</h2>
+      <Styled.Container></Styled.Container>
+      <Footer />
     </Layout>
   );
 };

--- a/apps/admin/src/pages/Login/LoginPage.tsx
+++ b/apps/admin/src/pages/Login/LoginPage.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { KakaotalkIcon, AppleIcon } from '@boolti/icon';
 import Styled from './LoginPage.styles';
-import { PATH } from '../../constants/routes';
+import { PATH } from '~/constants/routes';
 
 declare global {
   interface Window {

--- a/apps/admin/src/pages/OAuth/OAuthKakaoPage.tsx
+++ b/apps/admin/src/pages/OAuth/OAuthKakaoPage.tsx
@@ -1,8 +1,8 @@
 import { useKakaoLogin, useKakaoToken, useKakaoUserInfo, useSignUp } from '@boolti/api';
 import { useEffect, useCallback, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import LOCAL_STORAGE from '../../constants/localStorage';
-import { PATH } from '../../constants/routes';
+import LOCAL_STORAGE from '~/constants/localStorage';
+import { PATH } from '~/constants/routes';
 
 const OAuthKakaoPage = () => {
   const location = useLocation();

--- a/apps/admin/src/pages/SignUpComplete/SignUpCompletePage.tsx
+++ b/apps/admin/src/pages/SignUpComplete/SignUpCompletePage.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import Styled from './SignUpCompletePage.styles';
-import { PATH } from '../../constants/routes';
+import { PATH } from '~/constants/routes';
 
 const SignUpCompletePage = () => {
   const navigate = useNavigate();

--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -1,5 +1,11 @@
 {
   "extends": "@boolti/typescript-config/vite.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["src/*"]
+    }
+  },
   "include": [
     "src"
   ]

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -3,6 +3,9 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  resolve: {
+    alias: [{ find: '~', replacement: '/src' }],
+  },
   server: {
     port: 8080,
   },

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -8,7 +8,7 @@ import type { Decorator, Preview } from '@storybook/react';
 const preview: Preview = {
   parameters: {
     darkMode: {
-      dark: themes.dark,
+      dark: undefined,
       light: themes.normal,
       stylePreview: true,
       current: 'light'

--- a/packages/ui/src/components/Footer/Footer.styles.ts
+++ b/packages/ui/src/components/Footer/Footer.styles.ts
@@ -2,13 +2,12 @@ import styled from '@emotion/styled';
 
 const Container = styled.footer`
   padding: 60px 20px;
+  width: ${({ theme }) => theme.breakpoint.desktop};
 `;
 
 const Content = styled.div`
   display: flex;
-  margin: 0 auto;
   justify-content: space-between;
-  width: ${({ theme }) => theme.breakpoint.desktop};
 `;
 
 const TextGroup = styled.div`


### PR DESCRIPTION
컴포넌트의 props나 내부 비즈니스 로직은 없이 UI만 작업

- 공연 있는 경우

<img width="1727" alt="image" src="https://github.com/Nexters/boolti-web/assets/30997311/169a4c5b-afcb-4cdf-b4b8-09135907b0ba">

- 공연 없는 경우

<img width="1728" alt="image" src="https://github.com/Nexters/boolti-web/assets/30997311/e33e72d2-1ecd-4ca1-89dd-8fecd109a42d">

- 계좌 정보 없는 경우

<img width="1681" alt="image" src="https://github.com/Nexters/boolti-web/assets/30997311/0fdd32f9-63a1-4ba4-94e4-f28985c46934">
