### PR TITLE
fix: 랜딩/QR 페이지 헤더 로고 클릭 시 동작 추가

### DIFF
--- a/apps/admin/src/pages/Landing/components/Header/Header.styles.ts
+++ b/apps/admin/src/pages/Landing/components/Header/Header.styles.ts
@@ -35,6 +35,9 @@ const HeaderContaienr = styled(m.div)`
 const BooltiIcon = styled.div`
   width: 55.5px;
   height: 21px;
+  cursor: pointer;
+  z-index: 1;
+
   ${mq} {
     width: 74px;
     height: 28px;

--- a/apps/admin/src/pages/Landing/components/Header/Header.styles.ts
+++ b/apps/admin/src/pages/Landing/components/Header/Header.styles.ts
@@ -32,7 +32,7 @@ const HeaderContaienr = styled(m.div)`
   }
 `;
 
-const BooltiIcon = styled.div`
+const BooltiIcon = styled.button`
   width: 55.5px;
   height: 21px;
   cursor: pointer;

--- a/apps/admin/src/pages/Landing/components/Header/index.tsx
+++ b/apps/admin/src/pages/Landing/components/Header/index.tsx
@@ -57,7 +57,7 @@ const Header = () => {
           },
         }}
       >
-        <Styled.BooltiIcon>
+        <Styled.BooltiIcon onClick={() => scrollTo({ top: 0, behavior: 'smooth' })}>
           <BooltiDark />
         </Styled.BooltiIcon>
 

--- a/apps/admin/src/pages/QRPage/QRPage.styles.ts
+++ b/apps/admin/src/pages/QRPage/QRPage.styles.ts
@@ -1,10 +1,11 @@
 import styled from '@emotion/styled';
+import { Link } from 'react-router-dom';
 
 const QRCodePage = styled.div`
   background-color: ${({ theme }) => theme.palette.grey.g00};
 `;
 
-const Logo = styled.div`
+const Logo = styled(Link)`
   width: 74px;
   height: 28px;
   margin-right: 48px;

--- a/apps/admin/src/pages/QRPage/QRPage.styles.ts
+++ b/apps/admin/src/pages/QRPage/QRPage.styles.ts
@@ -1,4 +1,3 @@
-import { mq } from '@boolti/ui';
 import styled from '@emotion/styled';
 
 const QRCodePage = styled.div`
@@ -6,16 +5,10 @@ const QRCodePage = styled.div`
 `;
 
 const Logo = styled.div`
-  display: inline-flex;
-  justify-content: flex-start;
-  align-items: center;
-  width: 60px;
-  height: 22.7px;
-
-  ${mq} {
-    width: 120px;
-    height: 44px;
-  }
+  width: 74px;
+  height: 28px;
+  margin-right: 48px;
+  cursor: pointer;
 `;
 
 const QRCodeContents = styled.div`

--- a/apps/admin/src/pages/QRPage/QRPage.tsx
+++ b/apps/admin/src/pages/QRPage/QRPage.tsx
@@ -33,7 +33,7 @@ const QRPage = () => {
           <Header
             left={
               <>
-                <Styled.Logo onClick={() => navigate(PATH.INDEX)}>
+                <Styled.Logo to={PATH.INDEX}>
                   <BooltiLogo />
                 </Styled.Logo>
                 {/* TODO: 공연 준비하기 페이지로 이동 */}

--- a/apps/admin/src/pages/QRPage/QRPage.tsx
+++ b/apps/admin/src/pages/QRPage/QRPage.tsx
@@ -33,7 +33,9 @@ const QRPage = () => {
           <Header
             left={
               <>
-                <Styled.Logo>
+                <Styled.Logo
+                  onClick={() => navigate(PATH.INDEX)}
+                >
                   <BooltiLogo />
                 </Styled.Logo>
                 {/* TODO: 공연 준비하기 페이지로 이동 */}

--- a/apps/admin/src/pages/QRPage/QRPage.tsx
+++ b/apps/admin/src/pages/QRPage/QRPage.tsx
@@ -33,9 +33,7 @@ const QRPage = () => {
           <Header
             left={
               <>
-                <Styled.Logo
-                  onClick={() => navigate(PATH.INDEX)}
-                >
+                <Styled.Logo onClick={() => navigate(PATH.INDEX)}>
                   <BooltiLogo />
                 </Styled.Logo>
                 {/* TODO: 공연 준비하기 페이지로 이동 */}


### PR DESCRIPTION
## 랜딩 페이지
- 헤더 로고 클릭 시 페이지 최상단으로 스무스 스크롤 이동.
- 숨겨진 버튼 때문에 로고 클릭 동작이 제대로 작동하지 않아서 로고에 z-index style 추가

## QR 페이지
- 헤더 로고 클릭 시 랜딩 페이지로 이동
- 로고 컨테이너 스타일 일부 수정