### PR TITLE
fix: 랜딩, QR 페이지 디자인 QA 3차

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -5,7 +5,13 @@ import { LOCAL_STORAGE, QueryClientProvider } from '@boolti/api';
 import { BooltiUIProvider } from '@boolti/ui';
 import { setDefaultOptions } from 'date-fns';
 import { ko } from 'date-fns/locale';
-import { createBrowserRouter, Navigate, Outlet, RouterProvider } from 'react-router-dom';
+import {
+  createBrowserRouter,
+  Navigate,
+  Outlet,
+  RouterProvider,
+  ScrollRestoration,
+} from 'react-router-dom';
 
 import AuthErrorBoundary from './components/ErrorBoundary/AuthErrorBoundary';
 import { PATH } from './constants/routes';
@@ -29,6 +35,12 @@ setDefaultOptions({ locale: ko });
 
 const publicRoutes = [
   {
+    element: (
+      <>
+        <ScrollRestoration />
+        <Outlet />
+      </>
+    ),
     children: [
       {
         path: PATH.INDEX,
@@ -71,7 +83,12 @@ const PrivateRoute = () => {
     return <Navigate to={PATH.LOGIN} replace />;
   }
 
-  return <Outlet />;
+  return (
+    <>
+      <ScrollRestoration />
+      <Outlet />
+    </>
+  );
 };
 
 const privateRoutes = [

--- a/apps/admin/src/components/ProfileDropdown/index.tsx
+++ b/apps/admin/src/components/ProfileDropdown/index.tsx
@@ -4,6 +4,8 @@ import { TextButton } from '@boolti/ui';
 import { useDropdown } from '@boolti/ui/src/hooks';
 
 import Styled from './ProfileDropdown.styles';
+import { useNavigate } from 'react-router-dom';
+import { PATH } from '~/constants/routes';
 
 interface ProfileDropdownProps {
   image?: string;
@@ -32,6 +34,7 @@ const ProfileSVG = () => (
 const ProfileDropdown = ({ image }: ProfileDropdownProps) => {
   const { isOpen, toggleDropdown } = useDropdown();
   const logoutMutation = useLogout();
+  const navigate = useNavigate();
 
   return (
     <Styled.DropdownContainer onClick={() => toggleDropdown()}>
@@ -47,6 +50,10 @@ const ProfileDropdown = ({ image }: ProfileDropdownProps) => {
             colorTheme="netural"
             onClick={async () => {
               await logoutMutation.mutateAsync();
+              if (location.pathname === PATH.INDEX) {
+                location.reload()
+              }
+              navigate(PATH.INDEX, { replace: true });
             }}
           >
             로그아웃

--- a/apps/admin/src/components/ProfileDropdown/index.tsx
+++ b/apps/admin/src/components/ProfileDropdown/index.tsx
@@ -2,10 +2,11 @@ import { useLogout } from '@boolti/api';
 import { ChevronDownIcon, ChevronUpIcon } from '@boolti/icon';
 import { TextButton } from '@boolti/ui';
 import { useDropdown } from '@boolti/ui/src/hooks';
+import { useNavigate } from 'react-router-dom';
+
+import { PATH } from '~/constants/routes';
 
 import Styled from './ProfileDropdown.styles';
-import { useNavigate } from 'react-router-dom';
-import { PATH } from '~/constants/routes';
 
 interface ProfileDropdownProps {
   image?: string;
@@ -51,7 +52,7 @@ const ProfileDropdown = ({ image }: ProfileDropdownProps) => {
             onClick={async () => {
               await logoutMutation.mutateAsync();
               if (location.pathname === PATH.INDEX) {
-                location.reload()
+                location.reload();
               }
               navigate(PATH.INDEX, { replace: true });
             }}

--- a/apps/admin/src/pages/HomePage/HomePage.styles.ts
+++ b/apps/admin/src/pages/HomePage/HomePage.styles.ts
@@ -2,12 +2,13 @@ import { mq } from '@boolti/ui';
 import styled from '@emotion/styled';
 import { Link } from 'react-router-dom';
 
-const Logo = styled.div`
+const Logo = styled(Link)`
   display: inline-flex;
   justify-content: flex-start;
   align-items: center;
   width: 60px;
   height: 22.7px;
+  cursor: pointer;
 
   ${mq} {
     width: 174px;

--- a/apps/admin/src/pages/HomePage/HomePage.tsx
+++ b/apps/admin/src/pages/HomePage/HomePage.tsx
@@ -32,7 +32,7 @@ const HomePage = () => {
       header={
         <Header
           left={
-            <Styled.Logo>
+            <Styled.Logo to={PATH.INDEX}>
               <BooltiLogo />
             </Styled.Logo>
           }

--- a/apps/admin/src/pages/Landing/components/Tab/index.tsx
+++ b/apps/admin/src/pages/Landing/components/Tab/index.tsx
@@ -5,7 +5,7 @@ import Styled from './Tab.styles';
 
 const items = [
   { key: 'organizer', children: '주최자용 웹' },
-  { key: 'user', children: '예매자용 웹' },
+  { key: 'user', children: '예매자용 앱' },
 ] as const;
 
 const Tab = () => {

--- a/apps/admin/src/pages/QRPage/QRPage.tsx
+++ b/apps/admin/src/pages/QRPage/QRPage.tsx
@@ -17,8 +17,8 @@ import Styled from './QRPage.styles';
 
 const QRPage = () => {
   const theme = useTheme();
-  const { data: userAccountInfoData } = useUserSummary();
   const [isLogin] = useState(Boolean(getIsLogin()));
+  const { data: userAccountInfoData } = useUserSummary({ enabled: isLogin });
   const navigate = useNavigate();
 
   return (


### PR DESCRIPTION
- 홈 페이지 > 헤더 로고 클릭 시 랜딩 페이지로 이동
- 랜딩 페이지 헤더 메뉴 > 예메자용 웹 -> 예매자용 앱으로 워딩 수정
- 비로그인 상태에서 QR 페이지 접근 시 user api 호출하지 않도록 처리
- ProfileDropdown 로그아웃 후 라우팅 처리
- 페이지 라우팅 시에 스크롤 최상단에 위치하도록 수정