### PR TITLE
fix: 티켓 관리 판매 시작일 관련 버그 수정

### DIFF
--- a/apps/admin/src/components/ShowInfoFormContent/ShowSalesTicketFormContent.tsx
+++ b/apps/admin/src/components/ShowInfoFormContent/ShowSalesTicketFormContent.tsx
@@ -107,7 +107,7 @@ const ShowSalesTicketFormContent = ({
                       </Badge>
                     </Styled.TicketTitle>
                     <Styled.TicketDescription>
-                      {ticket.price}원 · 1인당 1매
+                      {ticket.price}원
                     </Styled.TicketDescription>
                   </Styled.TicketInfo>
                   <Styled.TicketAction>

--- a/apps/admin/src/components/ShowInfoFormContent/ShowTicketInfoFormContent.tsx
+++ b/apps/admin/src/components/ShowInfoFormContent/ShowTicketInfoFormContent.tsx
@@ -54,7 +54,7 @@ const ShowTicketInfoFormContent = ({
                         setHasBlurred((prev) => ({ ...prev, startDate: true }));
                       }}
                       placeholder={value}
-                      min={format(new Date(), 'yyyy-MM-dd')}
+                      min={format(salesStartTime ?? new Date(), 'yyyy-MM-dd')}
                       max={format(
                         sub(showDate ? new Date(showDate) : new Date(), { days: 1 }),
                         'yyyy-MM-dd',
@@ -91,7 +91,7 @@ const ShowTicketInfoFormContent = ({
                       placeholder={value}
                       min={format(
                         watch('startDate') ||
-                          (salesStartTime ? new Date(salesStartTime) : new Date()),
+                        (salesStartTime ? new Date(salesStartTime) : new Date()),
                         'yyyy-MM-dd',
                       )}
                       max={format(


### PR DESCRIPTION
- 티켓 판매 기간 수정 시, 최소 판매 시작일을 최초에 선택한 판매 시작일도 선택할 수 있도록 수정
- 일반 티켓 1인당 1매 표시 삭제