### PR TITLE
feat: isLogin 값 전역 상태로 관리

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -78,7 +78,7 @@ const publicRoutes = [
 const PrivateRoute = () => {
   const { isLogin } = useAuthAtom();
 
-  if (!isLogin) {
+  if (!isLogin()) {
     return <Navigate to={PATH.LOGIN} replace />;
   }
 

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -1,7 +1,7 @@
 import 'the-new-css-reset/css/reset.css';
 import './index.css';
 
-import { LOCAL_STORAGE, QueryClientProvider } from '@boolti/api';
+import { QueryClientProvider } from '@boolti/api';
 import { BooltiUIProvider } from '@boolti/ui';
 import { setDefaultOptions } from 'date-fns';
 import { ko } from 'date-fns/locale';
@@ -30,6 +30,7 @@ import ShowSettlementPage from './pages/ShowSettlementPage/ShowSettlementPage';
 import ShowTicketPage from './pages/ShowTicketPage/ShowTicketPage';
 import SignUpCompletePage from './pages/SignUpComplete/SignUpCompletePage';
 import SitePolicyPage from './pages/SitePolicyPage/SitePolicyPage';
+import { useAuthAtom } from './atoms/useAuthAtom';
 
 setDefaultOptions({ locale: ko });
 
@@ -75,9 +76,7 @@ const publicRoutes = [
 ];
 
 const PrivateRoute = () => {
-  const isLogin =
-    window.localStorage.getItem(LOCAL_STORAGE.ACCESS_TOKEN) &&
-    window.localStorage.getItem(LOCAL_STORAGE.REFRESH_TOKEN);
+  const { isLogin } = useAuthAtom();
 
   if (!isLogin) {
     return <Navigate to={PATH.LOGIN} replace />;

--- a/apps/admin/src/atoms/useAuthAtom.ts
+++ b/apps/admin/src/atoms/useAuthAtom.ts
@@ -1,0 +1,52 @@
+import { LOCAL_STORAGE } from '@boolti/api';
+import { useAtom } from 'jotai';
+import { atomWithStorage, RESET } from 'jotai/utils';
+import { useMemo } from 'react';
+
+const storageMethod = {
+  getItem: (key: string, initialValue: string | null) => {
+    return window.localStorage.getItem(key) ?? initialValue;
+  },
+  setItem: (key: string, value: string | null) => {
+    window.localStorage.setItem(key, value as string);
+  },
+  removeItem: (key: string) => {
+    window.localStorage.removeItem(key);
+  },
+};
+const accessTokenAtom = atomWithStorage<string | null>(
+  LOCAL_STORAGE.ACCESS_TOKEN,
+  window.localStorage.getItem(LOCAL_STORAGE.ACCESS_TOKEN),
+  storageMethod,
+);
+const refreshTokenAtom = atomWithStorage<string | null>(
+  LOCAL_STORAGE.REFRESH_TOKEN,
+  window.localStorage.getItem(LOCAL_STORAGE.REFRESH_TOKEN),
+  storageMethod,
+);
+
+export const useAuthAtom = () => {
+  const [accessToken, setAccessToken] = useAtom(accessTokenAtom);
+  const [refreshToken, setRefreshToken] = useAtom(refreshTokenAtom);
+
+  const login = (accessToken: string, refreshToken: string) => {
+    setAccessToken(accessToken);
+    setRefreshToken(refreshToken);
+  };
+
+  const logout = () => {
+    setAccessToken(RESET);
+    setRefreshToken(RESET);
+  };
+
+  const isLogin = useMemo(() => {
+    console.log(accessToken, refreshToken);
+    return !!accessToken && !!refreshToken;
+  }, [accessToken, refreshToken]);
+
+  return {
+    login,
+    logout,
+    isLogin,
+  };
+};

--- a/apps/admin/src/atoms/useAuthAtom.ts
+++ b/apps/admin/src/atoms/useAuthAtom.ts
@@ -1,7 +1,6 @@
 import { LOCAL_STORAGE } from '@boolti/api';
 import { useAtom } from 'jotai';
 import { atomWithStorage, RESET } from 'jotai/utils';
-import { useMemo } from 'react';
 
 const storageMethod = {
   getItem: (key: string, initialValue: string | null) => {
@@ -39,9 +38,7 @@ export const useAuthAtom = () => {
     setRefreshToken(RESET);
   };
 
-  const isLogin = useMemo(() => {
-    return !!accessToken && !!refreshToken;
-  }, [accessToken, refreshToken]);
+  const isLogin = () => !!accessToken && !!refreshToken;
 
   return {
     setToken,

--- a/apps/admin/src/atoms/useAuthAtom.ts
+++ b/apps/admin/src/atoms/useAuthAtom.ts
@@ -29,24 +29,23 @@ export const useAuthAtom = () => {
   const [accessToken, setAccessToken] = useAtom(accessTokenAtom);
   const [refreshToken, setRefreshToken] = useAtom(refreshTokenAtom);
 
-  const login = (accessToken: string, refreshToken: string) => {
+  const setToken = (accessToken: string, refreshToken: string) => {
     setAccessToken(accessToken);
     setRefreshToken(refreshToken);
   };
 
-  const logout = () => {
+  const removeToken = () => {
     setAccessToken(RESET);
     setRefreshToken(RESET);
   };
 
   const isLogin = useMemo(() => {
-    console.log(accessToken, refreshToken);
     return !!accessToken && !!refreshToken;
   }, [accessToken, refreshToken]);
 
   return {
-    login,
-    logout,
+    setToken,
+    removeToken,
     isLogin,
   };
 };

--- a/apps/admin/src/components/ProfileDropdown/index.tsx
+++ b/apps/admin/src/components/ProfileDropdown/index.tsx
@@ -53,9 +53,6 @@ const ProfileDropdown = ({ image }: ProfileDropdownProps) => {
             colorTheme="netural"
             onClick={async () => {
               await logoutMutation.mutateAsync();
-              if (location.pathname === PATH.INDEX) {
-                location.reload();
-              }
               navigate(PATH.INDEX, { replace: true });
             }}
           >

--- a/apps/admin/src/components/ProfileDropdown/index.tsx
+++ b/apps/admin/src/components/ProfileDropdown/index.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from 'react-router-dom';
 import { PATH } from '~/constants/routes';
 
 import Styled from './ProfileDropdown.styles';
+import { useAuthAtom } from '~/atoms/useAuthAtom';
 
 interface ProfileDropdownProps {
   image?: string;
@@ -34,7 +35,8 @@ const ProfileSVG = () => (
 
 const ProfileDropdown = ({ image }: ProfileDropdownProps) => {
   const { isOpen, toggleDropdown } = useDropdown();
-  const logoutMutation = useLogout();
+  const { removeToken } = useAuthAtom();
+  const logoutMutation = useLogout({}, removeToken);
   const navigate = useNavigate();
 
   return (

--- a/apps/admin/src/components/ProfileDropdown/index.tsx
+++ b/apps/admin/src/components/ProfileDropdown/index.tsx
@@ -36,7 +36,11 @@ const ProfileSVG = () => (
 const ProfileDropdown = ({ image }: ProfileDropdownProps) => {
   const { isOpen, toggleDropdown } = useDropdown();
   const { removeToken } = useAuthAtom();
-  const logoutMutation = useLogout({}, removeToken);
+  const logoutMutation = useLogout({
+    onSuccess: () => {
+      removeToken();
+    },
+  });
   const navigate = useNavigate();
 
   return (

--- a/apps/admin/src/components/ShowDetailLayout/index.tsx
+++ b/apps/admin/src/components/ShowDetailLayout/index.tsx
@@ -11,6 +11,7 @@ import { HREF, PATH } from '~/constants/routes';
 import Header from '../Header/index.tsx';
 import Layout from '../Layout/index.tsx';
 import Styled from './ShowDetailLayout.styles.ts';
+import { useAuthAtom } from '~/atoms/useAuthAtom.ts';
 
 const settlementTooltipText = {
   SEND: '내역서 확인 및 정산 요청을 진행해 주세요',
@@ -35,7 +36,7 @@ const ShowDetailLayout = ({ showName, children, onClickMiddleware }: ShowDetailL
     initialInView: true,
   });
   const theme = useTheme();
-
+  const { removeToken } = useAuthAtom();
   const navigate = useNavigate();
   const params = useParams<{ showId: string }>();
   const matchInfoTab = useMatch(PATH.SHOW_INFO);
@@ -46,7 +47,7 @@ const ShowDetailLayout = ({ showName, children, onClickMiddleware }: ShowDetailL
 
   const { data: lastSettlementEvent } = useShowLastSettlementEvent(Number(params!.showId));
   const { data: settlementInfo } = useShowSettlementInfo(Number(params!.showId));
-  const logoutMutation = useLogout();
+  const logoutMutation = useLogout({}, removeToken);
 
   const tooltipStyle = {
     color: theme.palette.grey.w,

--- a/apps/admin/src/components/ShowDetailLayout/index.tsx
+++ b/apps/admin/src/components/ShowDetailLayout/index.tsx
@@ -47,7 +47,11 @@ const ShowDetailLayout = ({ showName, children, onClickMiddleware }: ShowDetailL
 
   const { data: lastSettlementEvent } = useShowLastSettlementEvent(Number(params!.showId));
   const { data: settlementInfo } = useShowSettlementInfo(Number(params!.showId));
-  const logoutMutation = useLogout({}, removeToken);
+  const logoutMutation = useLogout({
+    onSuccess: () => {
+      removeToken();
+    },
+  });
 
   const tooltipStyle = {
     color: theme.palette.grey.w,

--- a/apps/admin/src/pages/HomePage/HomePage.tsx
+++ b/apps/admin/src/pages/HomePage/HomePage.tsx
@@ -27,7 +27,11 @@ const bannerDescription = {
 const HomePage = () => {
   const { removeToken } = useAuthAtom();
   const navigate = useNavigate();
-  const logout = useLogout({}, removeToken);
+  const logout = useLogout({
+    onSuccess: () => {
+      removeToken();
+    },
+  });
   const confirm = useConfirm();
 
   const { data: userAccountInfoData, isLoading: isUserAccountInfoLoading } = useUserAccountInfo();

--- a/apps/admin/src/pages/HomePage/HomePage.tsx
+++ b/apps/admin/src/pages/HomePage/HomePage.tsx
@@ -17,6 +17,7 @@ import UserProfile from '~/components/UserProfile';
 import { HREF, PATH } from '~/constants/routes';
 
 import Styled from './HomePage.styles';
+import { useAuthAtom } from '~/atoms/useAuthAtom';
 
 const bannerDescription = {
   REQUIRED: '공연의 정산 내역서가 도착했어요. 내역을 확인한 후 정산을 요청해 주세요.',
@@ -24,8 +25,9 @@ const bannerDescription = {
 };
 
 const HomePage = () => {
+  const { removeToken } = useAuthAtom();
   const navigate = useNavigate();
-  const logout = useLogout();
+  const logout = useLogout({}, removeToken);
   const confirm = useConfirm();
 
   const { data: userAccountInfoData, isLoading: isUserAccountInfoLoading } = useUserAccountInfo();

--- a/apps/admin/src/pages/Landing/components/Header/index.tsx
+++ b/apps/admin/src/pages/Landing/components/Header/index.tsx
@@ -10,13 +10,14 @@ import { LINK } from '~/constants/link';
 import { PATH } from '~/constants/routes';
 import { useDeviceWidth } from '~/hooks/useDeviceWidth';
 import { useScrollDirection } from '~/hooks/useScrollDirection';
-import { getIsLogin } from '~/utils/auth';
 
 import { visibleSectionAtom } from '../../atoms/visibleSectionAtom';
 import { Tab } from '..';
 import Styled from './Header.styles';
+import { useAuthAtom } from '~/atoms/useAuthAtom';
 
 const Header = () => {
+  const { isLogin, removeToken } = useAuthAtom();
   const currentVisibleSection = useAtomValue(visibleSectionAtom);
   const scrollDirection = useScrollDirection();
   const visible = currentVisibleSection === 'key-visal' || scrollDirection === 'up';
@@ -25,19 +26,16 @@ const Header = () => {
   const theme = useTheme();
   const isMobile = deviceWidth < parseInt(theme.breakpoint.mobile, 10);
 
-  const logout = useLogout();
+  const logout = useLogout({}, removeToken);
   const navigate = useNavigate();
 
   const [isExpanded, setIsExpanded] = useState(false);
-  const [isLogin, setIsLogin] = useState(Boolean(getIsLogin()));
-
   const { data } = useUserSummary({ enabled: isLogin });
   const { imagePath } = data ?? {};
 
   const onClickAuthButton = async () => {
     if (isLogin) {
       await logout.mutateAsync();
-      setIsLogin(false);
       return;
     }
 

--- a/apps/admin/src/pages/Landing/components/Header/index.tsx
+++ b/apps/admin/src/pages/Landing/components/Header/index.tsx
@@ -34,11 +34,11 @@ const Header = () => {
   const navigate = useNavigate();
 
   const [isExpanded, setIsExpanded] = useState(false);
-  const { data } = useUserSummary({ enabled: isLogin });
+  const { data } = useUserSummary({ enabled: isLogin() });
   const { imagePath } = data ?? {};
 
   const onClickAuthButton = async () => {
-    if (isLogin) {
+    if (isLogin()) {
       await logout.mutateAsync();
       return;
     }
@@ -80,7 +80,7 @@ const Header = () => {
             앱 바로가기
           </Styled.InternalLink>
           <Styled.InternalLink to={PATH.HOME}>공연 준비하기</Styled.InternalLink>
-          {isLogin ? (
+          {isLogin() ? (
             <Styled.DropDownContainer>
               <ProfileDropdown image={imagePath} />
             </Styled.DropDownContainer>
@@ -125,12 +125,12 @@ const Header = () => {
         </Styled.InternalLink>
         <Styled.InternalLink to={PATH.HOME}>공연 준비하기</Styled.InternalLink>
         <Styled.MobileAuthButton
-          colorTheme={isLogin ? 'netural' : 'primary'}
+          colorTheme={isLogin() ? 'netural' : 'primary'}
           size="bold"
           role="button"
           onClick={onClickAuthButton}
         >
-          {isLogin ? '로그아웃' : '로그인'}
+          {isLogin() ? '로그아웃' : '로그인'}
         </Styled.MobileAuthButton>
       </Styled.MobileMenu>
 

--- a/apps/admin/src/pages/Landing/components/Header/index.tsx
+++ b/apps/admin/src/pages/Landing/components/Header/index.tsx
@@ -26,7 +26,11 @@ const Header = () => {
   const theme = useTheme();
   const isMobile = deviceWidth < parseInt(theme.breakpoint.mobile, 10);
 
-  const logout = useLogout({}, removeToken);
+  const logout = useLogout({
+    onSuccess: () => {
+      removeToken();
+    },
+  });
   const navigate = useNavigate();
 
   const [isExpanded, setIsExpanded] = useState(false);

--- a/apps/admin/src/pages/Login/LoginPage.tsx
+++ b/apps/admin/src/pages/Login/LoginPage.tsx
@@ -49,7 +49,7 @@ declare global {
 const kakaoRedirectUri = `${window.location.origin}${PATH.OAUTH_KAKAO}`;
 
 const LoginPage = () => {
-  const { login } = useAuthAtom();
+  const { setToken } = useAuthAtom();
   const navigate = useNavigate();
 
   const appleLoginMutation = useAppleLogin();
@@ -71,7 +71,7 @@ const LoginPage = () => {
       oauthIdentity,
     });
 
-    login(accessToken, refreshToken);
+    setToken(accessToken, refreshToken);
     navigate(PATH.SIGNUP_COMPLETE, { replace: true });
   };
 
@@ -97,7 +97,7 @@ const LoginPage = () => {
         return;
       }
 
-      login(accessToken, refreshToken);
+      setToken(accessToken, refreshToken);
       navigate(PATH.HOME);
     } catch (error) {
       console.error(error);

--- a/apps/admin/src/pages/Login/LoginPage.tsx
+++ b/apps/admin/src/pages/Login/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { LOCAL_STORAGE, useAppleLogin, useSignUp } from '@boolti/api';
+import { useAppleLogin, useSignUp } from '@boolti/api';
 import { AppleIcon, BooltiSmallLogo, KakaotalkIcon } from '@boolti/icon';
 import { jwtDecode } from 'jwt-decode';
 import { useNavigate } from 'react-router-dom';
@@ -7,6 +7,7 @@ import { LINK } from '~/constants/link';
 import { PATH } from '~/constants/routes';
 
 import Styled from './LoginPage.styles';
+import { useAuthAtom } from '~/atoms/useAuthAtom';
 
 declare global {
   interface Window {
@@ -48,6 +49,7 @@ declare global {
 const kakaoRedirectUri = `${window.location.origin}${PATH.OAUTH_KAKAO}`;
 
 const LoginPage = () => {
+  const { login } = useAuthAtom();
   const navigate = useNavigate();
 
   const appleLoginMutation = useAppleLogin();
@@ -69,9 +71,7 @@ const LoginPage = () => {
       oauthIdentity,
     });
 
-    window.localStorage.setItem(LOCAL_STORAGE.ACCESS_TOKEN, accessToken);
-    window.localStorage.setItem(LOCAL_STORAGE.REFRESH_TOKEN, refreshToken);
-
+    login(accessToken, refreshToken);
     navigate(PATH.SIGNUP_COMPLETE, { replace: true });
   };
 
@@ -97,9 +97,7 @@ const LoginPage = () => {
         return;
       }
 
-      window.localStorage.setItem(LOCAL_STORAGE.ACCESS_TOKEN, accessToken);
-      window.localStorage.setItem(LOCAL_STORAGE.REFRESH_TOKEN, refreshToken);
-
+      login(accessToken, refreshToken);
       navigate(PATH.HOME);
     } catch (error) {
       console.error(error);

--- a/apps/admin/src/pages/OAuth/OAuthKakaoPage.tsx
+++ b/apps/admin/src/pages/OAuth/OAuthKakaoPage.tsx
@@ -44,7 +44,7 @@ const OAuthKakaoPage = () => {
       setToken(accessToken, refreshToken);
       navigate(PATH.SIGNUP_COMPLETE, { replace: true });
     },
-    [kakaoUserInfoMutation, navigate, signUpMutation],
+    [kakaoUserInfoMutation, navigate, signUpMutation, setToken],
   );
 
   const kakaoLogin = useCallback(async () => {
@@ -63,7 +63,7 @@ const OAuthKakaoPage = () => {
 
     setToken(accessToken, refreshToken);
     navigate(PATH.HOME);
-  }, [code, kakaoLoginMutation, kakaoSignUp, kakaoTokenMutation, navigate]);
+  }, [code, kakaoLoginMutation, kakaoSignUp, kakaoTokenMutation, navigate, setToken]);
 
   useEffect(() => {
     kakaoLogin();

--- a/apps/admin/src/pages/OAuth/OAuthKakaoPage.tsx
+++ b/apps/admin/src/pages/OAuth/OAuthKakaoPage.tsx
@@ -1,10 +1,4 @@
-import {
-  LOCAL_STORAGE,
-  useKakaoLogin,
-  useKakaoToken,
-  useKakaoUserInfo,
-  useSignUp,
-} from '@boolti/api';
+import { useKakaoLogin, useKakaoToken, useKakaoUserInfo, useSignUp } from '@boolti/api';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuthAtom } from '~/atoms/useAuthAtom';
@@ -12,7 +6,7 @@ import { useAuthAtom } from '~/atoms/useAuthAtom';
 import { PATH } from '~/constants/routes';
 
 const OAuthKakaoPage = () => {
-  const { login } = useAuthAtom();
+  const { setToken } = useAuthAtom();
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -47,7 +41,7 @@ const OAuthKakaoPage = () => {
         imgPath: userInfo.kakao_account?.profile?.profile_image_url,
       });
 
-      login(accessToken, refreshToken);
+      setToken(accessToken, refreshToken);
       navigate(PATH.SIGNUP_COMPLETE, { replace: true });
     },
     [kakaoUserInfoMutation, navigate, signUpMutation],
@@ -67,7 +61,7 @@ const OAuthKakaoPage = () => {
       return;
     }
 
-    login(accessToken, refreshToken);
+    setToken(accessToken, refreshToken);
     navigate(PATH.HOME);
   }, [code, kakaoLoginMutation, kakaoSignUp, kakaoTokenMutation, navigate]);
 

--- a/apps/admin/src/pages/OAuth/OAuthKakaoPage.tsx
+++ b/apps/admin/src/pages/OAuth/OAuthKakaoPage.tsx
@@ -7,10 +7,12 @@ import {
 } from '@boolti/api';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { useAuthAtom } from '~/atoms/useAuthAtom';
 
 import { PATH } from '~/constants/routes';
 
 const OAuthKakaoPage = () => {
+  const { login } = useAuthAtom();
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -45,9 +47,7 @@ const OAuthKakaoPage = () => {
         imgPath: userInfo.kakao_account?.profile?.profile_image_url,
       });
 
-      window.localStorage.setItem(LOCAL_STORAGE.ACCESS_TOKEN, accessToken);
-      window.localStorage.setItem(LOCAL_STORAGE.REFRESH_TOKEN, refreshToken);
-
+      login(accessToken, refreshToken);
       navigate(PATH.SIGNUP_COMPLETE, { replace: true });
     },
     [kakaoUserInfoMutation, navigate, signUpMutation],
@@ -67,9 +67,7 @@ const OAuthKakaoPage = () => {
       return;
     }
 
-    window.localStorage.setItem(LOCAL_STORAGE.ACCESS_TOKEN, accessToken);
-    window.localStorage.setItem(LOCAL_STORAGE.REFRESH_TOKEN, refreshToken);
-
+    login(accessToken, refreshToken);
     navigate(PATH.HOME);
   }, [code, kakaoLoginMutation, kakaoSignUp, kakaoTokenMutation, navigate]);
 

--- a/apps/admin/src/pages/QRPage/QRPage.tsx
+++ b/apps/admin/src/pages/QRPage/QRPage.tsx
@@ -3,7 +3,6 @@ import { BooltiGrey, BooltiLogo } from '@boolti/icon';
 import { Footer, TextButton } from '@boolti/ui';
 import { useTheme } from '@emotion/react';
 import { QRCodeSVG } from 'qrcode.react';
-import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import Header from '~/components/Header';
@@ -11,13 +10,13 @@ import Layout from '~/components/Layout';
 import ProfileDropdown from '~/components/ProfileDropdown';
 import { LINK } from '~/constants/link';
 import { PATH } from '~/constants/routes';
-import { getIsLogin } from '~/utils/auth';
 
 import Styled from './QRPage.styles';
+import { useAuthAtom } from '~/atoms/useAuthAtom';
 
 const QRPage = () => {
+  const { isLogin } = useAuthAtom();
   const theme = useTheme();
-  const [isLogin] = useState(Boolean(getIsLogin()));
   const { data: userAccountInfoData } = useUserSummary({ enabled: isLogin });
   const navigate = useNavigate();
 

--- a/apps/admin/src/pages/QRPage/QRPage.tsx
+++ b/apps/admin/src/pages/QRPage/QRPage.tsx
@@ -17,7 +17,7 @@ import { useAuthAtom } from '~/atoms/useAuthAtom';
 const QRPage = () => {
   const { isLogin } = useAuthAtom();
   const theme = useTheme();
-  const { data: userAccountInfoData } = useUserSummary({ enabled: isLogin });
+  const { data: userAccountInfoData } = useUserSummary({ enabled: isLogin() });
   const navigate = useNavigate();
 
   return (
@@ -41,7 +41,7 @@ const QRPage = () => {
               </>
             }
             right={
-              isLogin ? (
+              isLogin() ? (
                 <ProfileDropdown image={userAccountInfoData?.imagePath} />
               ) : (
                 <TextButton

--- a/apps/admin/src/utils/auth.ts
+++ b/apps/admin/src/utils/auth.ts
@@ -1,8 +1,0 @@
-import { LOCAL_STORAGE } from '@boolti/api';
-
-export const getIsLogin = () => {
-  return (
-    window.localStorage.getItem(LOCAL_STORAGE.ACCESS_TOKEN) &&
-    window.localStorage.getItem(LOCAL_STORAGE.REFRESH_TOKEN)
-  );
-};

--- a/packages/api/src/mutations/useLogout.ts
+++ b/packages/api/src/mutations/useLogout.ts
@@ -6,12 +6,16 @@ import { fetcher } from '../fetcher';
 
 const postLogout = () => fetcher.post('web/v1/logout');
 
-const useLogout = (options?: UseMutationOptions) =>
+const useLogout = (options?: UseMutationOptions, onSuccessCallback?: () => void) =>
   useMutation(postLogout, {
     ...options,
     onSuccess: (data, variables, context) => {
-      window.localStorage.removeItem(LOCAL_STORAGE.ACCESS_TOKEN);
-      window.localStorage.removeItem(LOCAL_STORAGE.REFRESH_TOKEN);
+      if (onSuccessCallback) {
+        onSuccessCallback();
+      } else {
+        window.localStorage.removeItem(LOCAL_STORAGE.ACCESS_TOKEN);
+        window.localStorage.removeItem(LOCAL_STORAGE.REFRESH_TOKEN);
+      }
 
       options?.onSuccess?.(data, variables, context);
     },

--- a/packages/api/src/mutations/useLogout.ts
+++ b/packages/api/src/mutations/useLogout.ts
@@ -6,18 +6,16 @@ import { fetcher } from '../fetcher';
 
 const postLogout = () => fetcher.post('web/v1/logout');
 
-const useLogout = (options?: UseMutationOptions, onSuccessCallback?: () => void) =>
+const useLogout = (options?: UseMutationOptions) =>
   useMutation(postLogout, {
     ...options,
     onSuccess: (data, variables, context) => {
-      if (onSuccessCallback) {
-        onSuccessCallback();
+      if (options?.onSuccess) {
+        options.onSuccess(data, variables, context);
       } else {
         window.localStorage.removeItem(LOCAL_STORAGE.ACCESS_TOKEN);
         window.localStorage.removeItem(LOCAL_STORAGE.REFRESH_TOKEN);
       }
-
-      options?.onSuccess?.(data, variables, context);
     },
   });
 


### PR DESCRIPTION
- useAuthAtom 추가
  - atomWithStorage 통해서 accessToken, refreshToken를 set하고 remove 할 수 있도록 설정
- useLogout mutation onSuccess callback method 파라미터 추가
  - useLogout 이용처에서 removeToken 파라미터로 전달하여 logout mutation onSuccess 시에 토큰 제거
- 로그인 영역에서 토큰 세팅하는 로직 useAuthAtom의 setToken으로 대체
