### PR TITLE
Fix: 공연 상세 미리보기 > 링크가 화면 바깥으로 튀어나가서 UI 깨지는 것 수정

### DIFF
--- a/packages/ui/src/components/ShowPreview/ShowPreview.styles.ts
+++ b/packages/ui/src/components/ShowPreview/ShowPreview.styles.ts
@@ -151,6 +151,7 @@ const ShowInfoSubtitle = styled.h4`
 const ShowInfoDescription = styled.p<ShowInfoDescriptionProps>`
   ${({ theme }) => theme.typo.b3};
   color: ${({ theme }) => theme.palette.mobile.grey.g30};
+  word-break: break-word;
 
   ${({ isFullContent }) =>
     isFullContent &&


### PR DESCRIPTION
### Background

<img width="429" alt="스크린샷 2024-08-31 오후 2 49 51" src="https://github.com/user-attachments/assets/f51dca20-e76c-44c6-acf6-164327d5b9ad">

preview 쪽에서 참고 링크가 길어져서 화면을 뚫고 나가고 좌우 스크롤이 가능해지는 버그가 있음

### Solution
`word-break: break-word;` 스타일 추가
