### PR TITLE
refac: 공연 상세는 레이지 로딩 하지 않으며 레이웃은 라우터에서 주입

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -25,11 +25,6 @@ import {
   OAuthKakaoPage,
   HomePage,
   ShowAddCompletePage,
-  ShowEnterancePage,
-  ShowInfoPage,
-  ShowReservationPage,
-  ShowSettlementPage,
-  ShowTicketPage,
   SignUpCompletePage,
   SitePolicyPage,
   GiftRegisterPage,
@@ -39,6 +34,12 @@ import {
 import ShowAddPage from './pages/ShowAddPage';
 import { Suspense } from 'react';
 import { domAnimation, LazyMotion } from 'framer-motion';
+import ShowDetailLayout from './components/ShowDetailLayout';
+import ShowInfoPage from './pages/ShowInfoPage';
+import ShowTicketPage from './pages/ShowTicketPage';
+import ShowReservationPage from './pages/ShowReservationPage';
+import ShowSettlementPage from './pages/ShowSettlementPage';
+import ShowEnterancePage from './pages/ShowEnterancePage';
 
 setDefaultOptions({ locale: ko });
 
@@ -125,14 +126,24 @@ const privateRoutes = [
       { path: PATH.HOME, element: <HomePage /> },
       { path: PATH.SHOW_ADD, element: <ShowAddPage step="info" /> },
       { path: PATH.SHOW_ADD_TICKET, element: <ShowAddPage step="ticket" /> },
-      { path: PATH.SHOW_INFO, element: <ShowInfoPage /> },
-      { path: PATH.SHOW_TICKET, element: <ShowTicketPage /> },
-      { path: PATH.SHOW_RESERVATION, element: <ShowReservationPage /> },
-      { path: PATH.SHOW_ENTRANCE, element: <ShowEnterancePage /> },
-      { path: PATH.SHOW_SETTLEMENT, element: <ShowSettlementPage /> },
       {
         path: PATH.SHOW_ADD_COMPLETE,
         element: <ShowAddCompletePage />,
+      },
+      {
+        path: '/',
+        element: (
+          <ShowDetailLayout>
+            <Outlet />
+          </ShowDetailLayout>
+        ),
+        children: [
+          { path: PATH.SHOW_INFO, element: <ShowInfoPage /> },
+          { path: PATH.SHOW_TICKET, element: <ShowTicketPage /> },
+          { path: PATH.SHOW_RESERVATION, element: <ShowReservationPage /> },
+          { path: PATH.SHOW_ENTRANCE, element: <ShowEnterancePage /> },
+          { path: PATH.SHOW_SETTLEMENT, element: <ShowSettlementPage /> },
+        ],
       },
     ],
   },

--- a/apps/admin/src/components/ShowCastInfoFormDialogContent/index.tsx
+++ b/apps/admin/src/components/ShowCastInfoFormDialogContent/index.tsx
@@ -99,7 +99,6 @@ const ShowCastInfoFormDialogContent = ({ onDelete, prevShowCastInfo, onSave }: P
           <Styled.Row key={field._id}>
             <Controller
               control={control}
-              defaultValue={field.userCode}
               render={({ field: { onChange, onBlur } }) => {
                 const value = field.userCode;
                 const isError = Boolean(

--- a/apps/admin/src/components/ShowInfoFormContent/ShowBasicInfoFormContent.tsx
+++ b/apps/admin/src/components/ShowInfoFormContent/ShowBasicInfoFormContent.tsx
@@ -33,7 +33,7 @@ const ShowBasicInfoFormContent = ({
   const { open, close, isOpen } = useDialog();
   const detailAdressInputRef = useRef<HTMLInputElement>(null);
 
-  const { watch, control, setValue } = form;
+  const { control, setValue } = form;
 
   const { getRootProps, getInputProps } = useDropzone({
     accept: {
@@ -176,7 +176,6 @@ const ShowBasicInfoFormContent = ({
                     setHasBlurred((prev) => ({ ...prev, date: true }));
                   }}
                   placeholder={value}
-                  defaultValue={watch('date')}
                   min={format(add(new Date(), { days: 1 }), 'yyyy-MM-dd')}
                   required
                   disabled={disabled}

--- a/apps/admin/src/components/ShowInfoFormContent/ShowTicketInfoFormContent.tsx
+++ b/apps/admin/src/components/ShowInfoFormContent/ShowTicketInfoFormContent.tsx
@@ -59,7 +59,6 @@ const ShowTicketInfoFormContent = ({
                         sub(showDate ? new Date(showDate) : new Date(), { days: 1 }),
                         'yyyy-MM-dd',
                       )}
-                      defaultValue={watch('startDate') || ''}
                       required
                       disabled={disabled}
                       errorMessage={
@@ -98,7 +97,6 @@ const ShowTicketInfoFormContent = ({
                         sub(showDate ? new Date(showDate) : new Date(), { days: 1 }),
                         'yyyy-MM-dd',
                       )}
-                      defaultValue={watch('endDate') || ''}
                       required
                       disabled={disabled}
                       errorMessage={

--- a/apps/admin/src/components/ShowListItem/index.tsx
+++ b/apps/admin/src/components/ShowListItem/index.tsx
@@ -8,6 +8,7 @@ import { PATH } from '~/constants/routes';
 
 import Styled from './ShowListItem.styles';
 import { HostType } from '@boolti/api/src/types/host';
+import { queryKeys, useQueryClient } from '@boolti/api';
 
 interface Props {
   isEmpty?: boolean;
@@ -68,6 +69,7 @@ const ShowListItem = ({
   salesStartTime,
   salesEndTime,
 }: Props) => {
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
   return (
     <Styled.Container as={isEmpty ? 'div' : 'li'}>
@@ -75,6 +77,12 @@ const ShowListItem = ({
         <Styled.EmptyText>아직 등록한 공연이 없어요.</Styled.EmptyText>
       ) : (
         <Styled.Button
+          onMouseDown={() => {
+            queryClient.prefetchQuery(queryKeys.show.detail(id));
+            queryClient.prefetchQuery(queryKeys.host.me(id));
+            queryClient.prefetchQuery(queryKeys.show.lastSettlementEvent(id));
+            queryClient.prefetchQuery(queryKeys.show.settlementInfo(id));
+          }}
           onClick={() => {
             if (myHostType === HostType.SUPPORTER) {
               navigate(generatePath(PATH.SHOW_RESERVATION, { showId: id.toString() }));

--- a/apps/admin/src/constants/routes.ts
+++ b/apps/admin/src/constants/routes.ts
@@ -1,19 +1,23 @@
 export const PATH = {
   INDEX: '/',
+  QR: '/qr',
+  HOME: '/home',
+
   LOGIN: '/login',
   OAUTH_KAKAO: '/oauth/kakao',
   OAUTH_APPLE: '/oauth/apple',
   SIGNUP_COMPLETE: '/signup/complete',
-  HOME: '/home',
+
   SHOW_ADD: '/show/add',
-  QR: '/qr',
   SHOW_ADD_TICKET: '/show/add/ticket',
   SHOW_ADD_COMPLETE: '/show/add/complete',
+
   SHOW_INFO: '/show/:showId/info',
   SHOW_TICKET: '/show/:showId/ticket',
   SHOW_RESERVATION: '/show/:showId/reservation',
   SHOW_ENTRANCE: '/show/:showId/enterance',
   SHOW_SETTLEMENT: '/show/:showId/settlement',
+
   SITE_POLICY: '/site-policy/:policyId',
   GIFT_INTRO: '/gift/:giftId',
   GIFT_REGISTER: '/gift/:giftId/register',

--- a/apps/admin/src/pages/ShowEnterancePage/index.tsx
+++ b/apps/admin/src/pages/ShowEnterancePage/index.tsx
@@ -13,7 +13,6 @@ import EnteranceTable from '~/components/EnteranceTable';
 import EntranceConfirmDialogContent from '~/components/EntranceConfirmDialogContent';
 import MobileCardList from '~/components/MobileCardList';
 import Pagination from '~/components/Pagination';
-import ShowDetailLayout from '~/components/ShowDetailLayout';
 import TicketTypeSelect from '~/components/TicketTypeSelect';
 
 import Styled from './ShowEnterancePage.styles';
@@ -82,7 +81,7 @@ const ShowEnterancePage = () => {
   const { managerCode } = enteranceInfo ?? {};
 
   return (
-    <ShowDetailLayout showName={show.name}>
+    <>
       {totalTicketCount === 0 ? (
         <Styled.EmptyContainer>
           <BooltiGreyIcon />
@@ -203,7 +202,7 @@ const ShowEnterancePage = () => {
           )}
         </Styled.Container>
       )}
-    </ShowDetailLayout>
+    </>
   );
 };
 

--- a/apps/admin/src/pages/ShowInfoPage/index.tsx
+++ b/apps/admin/src/pages/ShowInfoPage/index.tsx
@@ -109,7 +109,7 @@ const ShowInfoPage = () => {
       toast.success('공연 정보를 저장했습니다.');
       setPreviewDrawerOpen(false);
     },
-    [editShowInfoMutation, imageFiles, show, showImages, uploadShowImageMutation],
+    [editShowInfoMutation, imageFiles, show, showImages, toast, uploadShowImageMutation],
   );
 
   const confirmSaveShowInfo = useCallback(async () => {
@@ -130,7 +130,7 @@ const ShowInfoPage = () => {
     }
 
     return true;
-  }, [isImageFilesDirty, onSubmit, showInfoForm]);
+  }, [confirm, isImageFilesDirty, onSubmit, showInfoForm]);
 
   useEffect(() => {
     if (!show) return;

--- a/apps/admin/src/pages/ShowReservationPage/index.tsx
+++ b/apps/admin/src/pages/ShowReservationPage/index.tsx
@@ -11,7 +11,6 @@ import { useParams } from 'react-router-dom';
 import MobileCardList from '~/components/MobileCardList';
 import Pagination from '~/components/Pagination';
 import ReservationTable from '~/components/ReservationTable';
-import ShowDetailLayout from '~/components/ShowDetailLayout';
 import TicketTypeSelect from '~/components/TicketTypeSelect';
 
 import Styled from './ShowReservationPage.styles';
@@ -86,7 +85,7 @@ const ShowReservationPage = () => {
   } = reservationSummary;
 
   return (
-    <ShowDetailLayout showName={show.name}>
+    <>
       {totalSoldCount === 0 ? (
         <Styled.EmptyContainer>
           <BooltiGreyIcon />
@@ -208,7 +207,7 @@ const ShowReservationPage = () => {
           )}
         </Styled.Container>
       )}
-    </ShowDetailLayout>
+    </>
   );
 };
 

--- a/apps/admin/src/pages/ShowSettlementPage/index.tsx
+++ b/apps/admin/src/pages/ShowSettlementPage/index.tsx
@@ -23,7 +23,7 @@ import { Document, Page, pdfjs } from 'react-pdf';
 import { useParams } from 'react-router-dom';
 
 import FileInput from '~/components/FileInput/FileInput';
-import ShowDetailLayout, { myHostInfoAtom } from '~/components/ShowDetailLayout';
+import { myHostInfoAtom } from '~/components/ShowDetailLayout';
 
 import Styled from './ShowSettlementPage.styles';
 import { useAtom } from 'jotai';
@@ -86,7 +86,7 @@ const ShowSettlementPage = () => {
   if (!show) return null;
 
   return (
-    <ShowDetailLayout showName={show.name}>
+    <>
       {myHostInfo?.type !== HostType.MAIN ? (
         <ShowDetailUnauthorized
           pageName={'정산 관리'}
@@ -266,7 +266,7 @@ const ShowSettlementPage = () => {
           )}
         </Styled.ShowSettlementPage>
       )}
-    </ShowDetailLayout>
+    </>
   );
 };
 

--- a/apps/admin/src/pages/ShowTicketPage/index.tsx
+++ b/apps/admin/src/pages/ShowTicketPage/index.tsx
@@ -15,7 +15,7 @@ import { useEffect } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
 
-import ShowDetailLayout, { myHostInfoAtom } from '~/components/ShowDetailLayout';
+import { myHostInfoAtom } from '~/components/ShowDetailLayout';
 import ShowInvitationTicketFormContent from '~/components/ShowInfoFormContent/ShowInvitationTicketFormContent';
 import ShowSalesTicketFormContent from '~/components/ShowInfoFormContent/ShowSalesTicketFormContent';
 import ShowTicketInfoFormContent from '~/components/ShowInfoFormContent/ShowTicketInfoFormContent';
@@ -74,7 +74,7 @@ const ShowTicketPage = () => {
   if (!show || !showSalesInfo) return null;
 
   return (
-    <ShowDetailLayout showName={show.name}>
+    <>
       {myHostInfo?.type === HostType.SUPPORTER ? (
         <ShowDetailUnauthorized
           pageName={'티켓 관리'}
@@ -194,7 +194,7 @@ const ShowTicketPage = () => {
           </Styled.ShowTicketFormContent>
         </Styled.ShowTicketPage>
       )}
-    </ShowDetailLayout>
+    </>
   );
 };
 


### PR DESCRIPTION
## 해당 작업 이유

- 레이지 로딩 적용후 공연 상세에서 메뉴 이동시 깜빡임이 있는 것을 확인
- 처음에 레이아웃 분리하면 될 줄 알고 레이아웃을 통으로 분리해 외부에서 사용하고 아래만 갈아끼우게 설정함
- 해결이 되지 않아서 TabItem에서 쓰는 상태가 변해서 그런가 싶어서 분리해봄
- 근데 해결이 되지 않아서 레이지 로딩을 해당 부분만 제거함 (그랬더니 정상 동작함)

기존 구조에서 레이아웃 분리해 둔 것은 그냥 유지하는 방향으로 PR을 올립니다.
커밋을 나눠야하나.. 와다다 개발해버린 관계로 쪼갤 수 없게된 점.. 양해 부탁드립니다