### PR TITLE
에디터 및 공연 정보 QA 사항 반영

### DIFF
--- a/apps/admin/src/components/ShowInfoFormContent/ShowDetailInfoFormContent.tsx
+++ b/apps/admin/src/components/ShowInfoFormContent/ShowDetailInfoFormContent.tsx
@@ -38,7 +38,9 @@ const ShowDetailInfoFormContent = ({ form, disabled }: ShowDetailInfoFormContent
             rules={{
               required: true,
             }}
-            render={({ field: { onChange, onBlur, value = '' } }) => {
+            render={({ field: { onChange, onBlur, value } }) => {
+              if (value === undefined) return <></>;
+
               return (
                 <Styled.TextAreaContainer>
                   <MarkdownEditor

--- a/apps/admin/src/pages/ShowAddPage/index.tsx
+++ b/apps/admin/src/pages/ShowAddPage/index.tsx
@@ -61,7 +61,13 @@ const ShowAddPage = ({ step }: ShowAddPageProps) => {
   const [isTermsAccepted, setIsTermsAccepted] = useState<boolean>(false);
 
   const showBasicInfoForm = useForm<ShowBasicInfoFormInputs>();
-  const showDetailInfoForm = useForm<ShowDetailInfoFormInputs>();
+  const showDetailInfoForm = useForm<ShowDetailInfoFormInputs>({
+    defaultValues: {
+      notice: '',
+      hostName: '',
+      hostPhoneNumber: ''
+    }
+  });
   const showSalesInfoForm = useForm<ShowSalesInfoFormInputs>();
 
   const uploadShowImageMutation = useUploadShowImage();

--- a/packages/ui/src/components/ShowContentMarkdown/ShowContentMarkdown.styles.ts
+++ b/packages/ui/src/components/ShowContentMarkdown/ShowContentMarkdown.styles.ts
@@ -71,6 +71,18 @@ const MarkdownContent = styled.div<{ colorMode?: 'dark' | 'light' }>`
     border-top: 1px solid ${({ theme }) => theme.palette.grey.g20};
     margin: 16px 0;
   }
+
+  strong {
+    font-weight: 700;
+  }
+
+  em {
+    font-style: italic;
+  }
+  
+  u {
+    text-decoration: underline;
+  }
 `
 
 export default {

--- a/packages/ui/src/components/ShowPreview/ShowPreview.styles.ts
+++ b/packages/ui/src/components/ShowPreview/ShowPreview.styles.ts
@@ -199,6 +199,7 @@ const ShowInfoTitleButton = styled.button`
   ${({ theme }) => theme.typo.b3};
   color: ${({ theme }) => theme.palette.mobile.status.link};
   cursor: pointer;
+  white-space: nowrap;
 `;
 
 const ShowInfoMoreButton = styled.button`


### PR DESCRIPTION
- 공연 정보 페이지에서 다른 페이지 이동 후 돌아왔을 때 공연 내용 텍스트가 비어있는 문제 수정
- 공연장 복사 버튼에 줄바꿈이 일어나지 않도록 수정
- 공연 내용에서 누락된 스타일 적용