### PR TITLE
fix: escape newlines in changed_files JSON payload

### DIFF
--- a/.github/workflows/notify-policy-changes.yml
+++ b/.github/workflows/notify-policy-changes.yml
@@ -1,0 +1,51 @@
+name: Notify Policy Changes
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/admin/src/**'
+      - 'apps/super-admin/src/**'
+      - 'packages/api/src/**'
+      - 'packages/ui/src/**'
+
+jobs:
+  dispatch:
+    name: Dispatch to boolti-docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Collect changed files
+        id: changes
+        run: |
+          FILES=$(git diff --name-only HEAD~1 HEAD -- \
+            'apps/admin/src/**' \
+            'apps/super-admin/src/**' \
+            'packages/api/src/**' \
+            'packages/ui/src/**')
+          COUNT=$(echo "$FILES" | wc -l | tr -d ' ')
+          LIST=$(echo "$FILES" | head -10 | sed 's/^/- /' | jq -Rs '.')
+          LIST=${LIST:1:-1}  # strip outer quotes from jq output
+          echo "count=$COUNT" >> $GITHUB_OUTPUT
+          {
+            echo "list<<EOF"
+            echo "$LIST"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      - name: Dispatch to boolti-docs
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DOCS_DISPATCH_TOKEN }}
+          repository: ryanproback/boolti-docs
+          event-type: policy-changed
+          client-payload: |
+            {
+              "source_repo": "Nexters/boolti-web",
+              "commit_sha": "${{ github.sha }}",
+              "file_count": "${{ steps.changes.outputs.count }}",
+              "changed_files": "${{ steps.changes.outputs.list }}"
+            }


### PR DESCRIPTION
## Summary

- `notify-policy-changes.yml` 워크플로우에서 `changed_files` 값에 raw newline이 포함되어 `Bad control character in string literal in JSON` 에러가 발생하는 버그를 수정합니다.
- `jq -Rs '.'`를 사용하여 파일 목록의 개행 문자를 JSON-safe하게 이스케이프 처리합니다.
- boolti-api에서 동일한 이슈로 이미 수정한 패턴과 동일한 방식입니다.

## Changes

```diff
- LIST=$(echo "$FILES" | head -10 | sed 's/^/- /')
+ LIST=$(echo "$FILES" | head -10 | sed 's/^/- /' | jq -Rs '.')
+ LIST=${LIST:1:-1}  # strip outer quotes from jq output
```

## Test plan

- [ ] main 브랜치에 `apps/admin/src/**`, `packages/api/src/**` 등 경로의 파일이 push될 때 워크플로우가 정상 실행되는지 확인
- [ ] `boolti-docs` 레포로 dispatch되는 JSON payload에 파싱 에러가 발생하지 않는지 확인