### PR TITLE
fix: escape newlines in changed_files JSON payload

### DIFF
--- a/.github/workflows/notify-policy-changes.yml
+++ b/.github/workflows/notify-policy-changes.yml
@@ -1,0 +1,51 @@
+name: Notify Policy Changes
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/admin/src/**'
+      - 'apps/super-admin/src/**'
+      - 'packages/api/src/**'
+      - 'packages/ui/src/**'
+
+jobs:
+  dispatch:
+    name: Dispatch to boolti-docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Collect changed files
+        id: changes
+        run: |
+          FILES=$(git diff --name-only HEAD~1 HEAD -- \
+            'apps/admin/src/**' \
+            'apps/super-admin/src/**' \
+            'packages/api/src/**' \
+            'packages/ui/src/**')
+          COUNT=$(echo "$FILES" | wc -l | tr -d ' ')
+          LIST=$(echo "$FILES" | head -10 | sed 's/^/- /' | jq -Rs '.')
+          LIST=${LIST:1:-1}  # strip outer quotes from jq output
+          echo "count=$COUNT" >> $GITHUB_OUTPUT
+          {
+            echo "list<<EOF"
+            echo "$LIST"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      - name: Dispatch to boolti-docs
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DOCS_DISPATCH_TOKEN }}
+          repository: ryanproback/boolti-docs
+          event-type: policy-changed
+          client-payload: |
+            {
+              "source_repo": "Nexters/boolti-web",
+              "commit_sha": "${{ github.sha }}",
+              "file_count": "${{ steps.changes.outputs.count }}",
+              "changed_files": "${{ steps.changes.outputs.list }}"
+            }


### PR DESCRIPTION
## Summary
- `notify-policy-changes` 워크플로우에서 `changed_files`에 raw newline이 들어가 JSON 파싱 에러 발생하던 문제 수정
- `jq -Rs '.'`로 newline을 이스케이프 처리 (boolti-api와 동일한 패턴)

## 관련
- 실패 로그: https://github.com/Nexters/boolti-web/actions/runs/24059538157
- boolti-api 동일 수정: Nexters/boolti-api@9dd3b66

🤖 Generated with [Claude Code](https://claude.com/claude-code)