### PR TITLE
feat(landing): QA 2차 반영

### DIFF
--- a/apps/admin/src/pages/Landing/LandingPage.styles.ts
+++ b/apps/admin/src/pages/Landing/LandingPage.styles.ts
@@ -1,8 +1,7 @@
-import { mq_lg } from '@boolti/ui';
 import styled from '@emotion/styled';
 import { m } from 'framer-motion';
 
-import { mq_desktop } from './constants';
+import { mq_desktop, mq_lg } from './constants';
 
 const Container = styled(m.div)`
   overflow: hidden;
@@ -22,7 +21,7 @@ const FooterContainer = styled.div`
     padding-bottom: 60px;
     padding-left: 24px;
     padding-right: 24px;
-    max-width: 375px;
+    max-width: none;
 
     ${mq_lg} {
       max-width: 672px;

--- a/apps/admin/src/pages/Landing/components/FeatureCard/FeatureCard.styles.ts
+++ b/apps/admin/src/pages/Landing/components/FeatureCard/FeatureCard.styles.ts
@@ -1,7 +1,6 @@
-import { mq_lg } from '@boolti/ui';
 import styled from '@emotion/styled';
 
-import { LANDING_COLORS, mq_desktop } from '../../constants';
+import { LANDING_COLORS, mq_desktop, mq_lg } from '../../constants';
 
 const Card = styled.article`
   display: flex;
@@ -131,11 +130,11 @@ const MediaImage = styled.img`
 
 const MediaArrow = styled.div`
   position: absolute;
-  top: 50%;
+  top: 48%;
   left: 50%;
   transform: translate(-50%, -50%) rotate(90deg);
-  width: 32px;
-  height: 32px;
+  width: 20px;
+  height: 20px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -147,12 +146,17 @@ const MediaArrow = styled.div`
   }
 
   ${mq_lg} {
+    top: 50%;
+    left: 49%;
     transform: translate(-50%, -50%) rotate(0deg);
+    width: 40px;
+    height: 40px;
   }
 
   ${mq_desktop} {
-    width: 48px;
-    height: 48px;
+    left: 49.4%;
+    width: 64px;
+    height: 64px;
   }
 `;
 

--- a/apps/admin/src/pages/Landing/components/Header/Header.styles.ts
+++ b/apps/admin/src/pages/Landing/components/Header/Header.styles.ts
@@ -1,16 +1,16 @@
-import { mq_lg } from '@boolti/ui';
 import styled from '@emotion/styled';
 import { Link } from 'react-router-dom';
 
-import { LANDING_COLORS, mq_desktop } from '../../constants';
+import { LANDING_COLORS, mq_desktop, mq_lg } from '../../constants';
 
-const Header = styled.header`
+const Header = styled.header<{ hideBorder?: boolean }>`
   position: fixed;
   z-index: 10;
   top: 0;
   left: 0;
   width: 100%;
-  border-bottom: 1px solid ${LANDING_COLORS.headerBorder};
+  border-bottom: 1px solid
+    ${({ hideBorder }) => (hideBorder ? 'transparent' : LANDING_COLORS.headerBorder)};
   background: ${LANDING_COLORS.headerGlass};
   backdrop-filter: blur(80px);
   -webkit-backdrop-filter: blur(80px);
@@ -18,6 +18,7 @@ const Header = styled.header`
 
   ${mq_lg} {
     padding: 0 48px;
+    border-bottom: 1px solid ${LANDING_COLORS.headerBorder};
   }
 
   ${mq_desktop} {
@@ -31,7 +32,6 @@ const HeaderContaienr = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  max-width: 375px;
   height: 72px;
 
   ${mq_lg} {
@@ -144,8 +144,7 @@ const MobileMenuOverlay = styled.div<{ isOpen: boolean }>`
   -webkit-backdrop-filter: blur(80px);
   border-bottom: 1px solid ${LANDING_COLORS.headerBorder};
   z-index: 9;
-  padding: 12px 20px 20px;
-  gap: 10px;
+  padding: 0 0 20px;
 
   ${mq_lg} {
     display: none;
@@ -157,26 +156,29 @@ const MobileMenuItem = styled.button`
   justify-content: center;
   align-items: center;
   padding: 16px 20px;
-  border-radius: 12px;
   font-family: Pretendard, sans-serif;
   font-weight: 500;
   font-size: 16px;
   line-height: 1.3;
   color: #ffffff;
   cursor: pointer;
-  background: rgba(255, 255, 255, 0.08);
+  background: transparent;
+`;
+
+const MobileMenuPrimaryWrap = styled.div`
+  padding: 12px 20px 0;
 `;
 
 const MobileMenuPrimary = styled(Link)`
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 16px 20px;
-  border-radius: 12px;
+  padding: 13px 20px;
+  border-radius: 8px;
   font-family: Pretendard, sans-serif;
-  font-weight: 500;
+  font-weight: 600;
   font-size: 16px;
-  line-height: 1.3;
+  line-height: 22px;
   color: #ffffff;
   cursor: pointer;
   text-decoration: none;
@@ -195,5 +197,6 @@ export default {
   MobileMenuButton,
   MobileMenuOverlay,
   MobileMenuItem,
+  MobileMenuPrimaryWrap,
   MobileMenuPrimary,
 };

--- a/apps/admin/src/pages/Landing/components/Header/index.tsx
+++ b/apps/admin/src/pages/Landing/components/Header/index.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
 import { BooltiDark } from '@boolti/icon';
-import { useTheme } from '@emotion/react';
 import { useNavigate } from 'react-router-dom';
 
 import { PATH } from '~/constants/routes';
 import { useDeviceWidth } from '~/hooks/useDeviceWidth';
 import { openStoreLink } from '~/utils/link';
 
+import { LANDING_BREAKPOINT } from '../../constants';
 import Styled from './Header.styles';
 
 const MenuIcon = () => (
@@ -26,9 +26,8 @@ const CloseIcon = () => (
 
 const Header = () => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const theme = useTheme();
   const deviceWidth = useDeviceWidth();
-  const isMobile = deviceWidth < parseInt(theme.breakpoint.mobile, 10);
+  const isMobile = deviceWidth < LANDING_BREAKPOINT.tablet;
   const navigate = useNavigate();
 
   const handleAppExplore = () => {
@@ -41,7 +40,7 @@ const Header = () => {
 
   return (
     <>
-      <Styled.Header>
+      <Styled.Header hideBorder={mobileMenuOpen}>
         <Styled.HeaderContaienr>
           <Styled.BooltiIcon onClick={() => scrollTo({ top: 0, behavior: 'smooth' })}>
             <BooltiDark />
@@ -77,12 +76,14 @@ const Header = () => {
         >
           앱 둘러보기
         </Styled.MobileMenuItem>
-        <Styled.MobileMenuPrimary
-          to={PATH.HOME}
-          onClick={() => setMobileMenuOpen(false)}
-        >
-          시작하기
-        </Styled.MobileMenuPrimary>
+        <Styled.MobileMenuPrimaryWrap>
+          <Styled.MobileMenuPrimary
+            to={PATH.HOME}
+            onClick={() => setMobileMenuOpen(false)}
+          >
+            시작하기
+          </Styled.MobileMenuPrimary>
+        </Styled.MobileMenuPrimaryWrap>
       </Styled.MobileMenuOverlay>
     </>
   );

--- a/apps/admin/src/pages/Landing/components/Hero/Hero.styles.ts
+++ b/apps/admin/src/pages/Landing/components/Hero/Hero.styles.ts
@@ -1,8 +1,7 @@
-import { mq_lg } from '@boolti/ui';
 import styled from '@emotion/styled';
 import { keyframes } from '@emotion/react';
 
-import { LANDING_COLORS, mq_desktop } from '../../constants';
+import { LANDING_COLORS, mq_desktop, mq_lg } from '../../constants';
 
 const marquee = keyframes`
   0% { transform: translateX(0); }
@@ -144,20 +143,18 @@ const MarqueeTrack = styled.div`
 
 const ImageCard = styled.img`
   flex-shrink: 0;
-  width: 200px;
+  width: auto;
   height: 268px;
   border-radius: 16px;
-  object-fit: cover;
+  object-fit: contain;
   background-color: #2a2a3d;
   user-select: none;
 
   ${mq_lg} {
-    width: 240px;
     height: 322px;
   }
 
   ${mq_desktop} {
-    width: 280px;
     height: 376px;
   }
 `;

--- a/apps/admin/src/pages/Landing/components/HowToUse/HowToUse.styles.ts
+++ b/apps/admin/src/pages/Landing/components/HowToUse/HowToUse.styles.ts
@@ -1,8 +1,7 @@
-import { mq_lg } from '@boolti/ui';
 import styled from '@emotion/styled';
 import { Link } from 'react-router-dom';
 
-import { LANDING_COLORS, mq_desktop } from '../../constants';
+import { LANDING_COLORS, mq_desktop, mq_lg } from '../../constants';
 
 const Section = styled.section`
   position: relative;
@@ -32,14 +31,14 @@ const Section = styled.section`
 
 const Light = styled.img`
   position: absolute;
-  top: 0;
+  top: -16px;
   left: 50%;
   transform: translateX(-50%);
   width: 100%;
   max-width: 1200px;
   height: auto;
   pointer-events: none;
-  opacity: 0.8;
+  opacity: 1;
   z-index: 1;
 `;
 

--- a/apps/admin/src/pages/Landing/components/HowToUse/index.tsx
+++ b/apps/admin/src/pages/Landing/components/HowToUse/index.tsx
@@ -1,4 +1,3 @@
-import { useTheme } from '@emotion/react';
 import { useNavigate } from 'react-router-dom';
 
 import lightSvg from '~/assets/landing-v2/light.svg';
@@ -6,16 +5,15 @@ import { PATH } from '~/constants/routes';
 import { useDeviceWidth } from '~/hooks/useDeviceWidth';
 import { openStoreLink } from '~/utils/link';
 
-import { LANDING_COPY } from '../../constants';
+import { LANDING_BREAKPOINT, LANDING_COPY } from '../../constants';
 import { useVisibleSectionAtom } from '../../atoms/visibleSectionAtom';
 import Styled from './HowToUse.styles';
 
 const HowToUse = () => {
   const { ref } = useVisibleSectionAtom('how-to-use');
-  const theme = useTheme();
   const deviceWidth = useDeviceWidth();
   const navigate = useNavigate();
-  const isMobile = deviceWidth < parseInt(theme.breakpoint.mobile, 10);
+  const isMobile = deviceWidth < LANDING_BREAKPOINT.tablet;
 
   const handleSecondary = () => {
     if (isMobile) {

--- a/apps/admin/src/pages/Landing/components/Problem/Problem.styles.ts
+++ b/apps/admin/src/pages/Landing/components/Problem/Problem.styles.ts
@@ -1,7 +1,6 @@
-import { mq_lg } from '@boolti/ui';
 import styled from '@emotion/styled';
 
-import { mq_desktop } from '../../constants';
+import { mq_desktop, mq_lg } from '../../constants';
 
 const Section = styled.section`
   position: relative;
@@ -68,7 +67,6 @@ const FloatingLogo = styled.img<{
   width: ${({ width }) => width}px;
   height: ${({ height }) => height}px;
   object-fit: contain;
-  opacity: 0.55;
   user-select: none;
 `;
 

--- a/apps/admin/src/pages/Landing/components/Problem/index.tsx
+++ b/apps/admin/src/pages/Landing/components/Problem/index.tsx
@@ -1,5 +1,3 @@
-import { useTheme } from '@emotion/react';
-
 import problem1 from '~/assets/landing-v2/problem-1.png';
 import problem2 from '~/assets/landing-v2/problem-2.png';
 import problem3 from '~/assets/landing-v2/problem-3.png';
@@ -8,7 +6,7 @@ import problem5 from '~/assets/landing-v2/problem-5.png';
 import problem6 from '~/assets/landing-v2/problem-6.png';
 import { useDeviceWidth } from '~/hooks/useDeviceWidth';
 
-import { LANDING_COPY } from '../../constants';
+import { LANDING_BREAKPOINT, LANDING_COPY } from '../../constants';
 import { useVisibleSectionAtom } from '../../atoms/visibleSectionAtom';
 import Styled from './Problem.styles';
 
@@ -44,10 +42,9 @@ const MOBILE_FLOATING_LOGOS = [
 
 const Problem = () => {
   const { ref } = useVisibleSectionAtom('problem');
-  const theme = useTheme();
   const deviceWidth = useDeviceWidth();
-  const isDesktop = deviceWidth >= parseInt(theme.breakpoint.desktop, 10);
-  const isMobile = deviceWidth < parseInt(theme.breakpoint.mobile, 10);
+  const isDesktop = deviceWidth >= LANDING_BREAKPOINT.desktop;
+  const isMobile = deviceWidth < LANDING_BREAKPOINT.tablet;
 
   const logos = isDesktop
     ? DESKTOP_FLOATING_LOGOS

--- a/apps/admin/src/pages/Landing/components/SolutionFeatures/SolutionFeatures.styles.ts
+++ b/apps/admin/src/pages/Landing/components/SolutionFeatures/SolutionFeatures.styles.ts
@@ -1,7 +1,6 @@
-import { mq_lg } from '@boolti/ui';
 import styled from '@emotion/styled';
 
-import { mq_desktop } from '../../constants';
+import { mq_desktop, mq_lg } from '../../constants';
 
 const Section = styled.section`
   display: flex;

--- a/apps/admin/src/pages/Landing/components/SolutionHighlight/SolutionHighlight.styles.ts
+++ b/apps/admin/src/pages/Landing/components/SolutionHighlight/SolutionHighlight.styles.ts
@@ -1,7 +1,6 @@
-import { mq_lg } from '@boolti/ui';
 import styled from '@emotion/styled';
 
-import { LANDING_COLORS, mq_desktop } from '../../constants';
+import { LANDING_COLORS, mq_desktop, mq_lg } from '../../constants';
 
 const Section = styled.section`
   display: flex;
@@ -105,14 +104,29 @@ const TextCard = styled.div`
   background-color: #ffffff;
 
   ${mq_lg} {
-    gap: 18px;
+    gap: 20px;
     padding: 48px 40px;
   }
 
   ${mq_desktop} {
     flex: 0 0 33.3%;
-    gap: 20px;
+    gap: 28px;
     padding: 60px 52px;
+  }
+`;
+
+const TitleDescriptionGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+
+  ${mq_lg} {
+    gap: 12px;
+  }
+
+  ${mq_desktop} {
+    gap: 16px;
   }
 `;
 
@@ -140,7 +154,7 @@ const Chip = styled.span`
 
 const CardTitle = styled.h3`
   font-family: Pretendard, sans-serif;
-  font-weight: 500;
+  font-weight: 600;
   font-size: 20px;
   line-height: 1.35;
   letter-spacing: -0.02em;
@@ -153,7 +167,7 @@ const CardTitle = styled.h3`
   }
 
   ${mq_desktop} {
-    font-size: 24px;
+    font-size: 32px;
   }
 `;
 
@@ -162,6 +176,7 @@ const CardDescription = styled.p`
   font-weight: 400;
   font-size: 16px;
   line-height: 1.4;
+  letter-spacing: -0.02em;
   color: #a2a5b4;
   margin: 0;
 
@@ -170,7 +185,7 @@ const CardDescription = styled.p`
   }
 
   ${mq_desktop} {
-    font-size: 18px;
+    font-size: 24px;
   }
 `;
 
@@ -200,80 +215,64 @@ const PromoImage = styled.img<{ offset: 'back' | 'front' }>`
   max-width: 180px;
   height: auto;
   border-radius: 20px;
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.15);
 
   ${({ offset }) =>
     offset === 'back'
       ? `
-    bottom: -20%;
-    left: 8%;
-    transform: rotate(-10deg);
+    top: 15%;
+    left: 5.2%;
     z-index: 1;
   `
       : `
-    bottom: -32%;
-    right: 0%;
-    transform: rotate(6deg);
+    top: -16.25%;
+    left: 51%;
     z-index: 2;
   `}
 
   ${mq_lg} {
-    max-width: 200px;
-
-    ${({ offset }) =>
-      offset === 'back'
-        ? `
-      bottom: -15%;
-      left: 8%;
-    `
-        : `
-      bottom: -28%;
-      right: -5%;
-    `}
+    width: 43.9%;
+    max-width: 269px;
   }
 
   ${mq_desktop} {
-    max-width: 269px;
+    width: 269px;
+    height: 567px;
+    border-radius: 26px;
 
     ${({ offset }) =>
       offset === 'back'
         ? `
       top: 84px;
       left: 32px;
-      bottom: auto;
     `
         : `
       top: -91px;
-      right: 0;
-      bottom: auto;
+      left: 312.33px;
     `}
   }
 `;
 
 const PaymentWrap = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: flex-end;
+  position: relative;
   width: 100%;
   height: 100%;
   min-height: 200px;
-  padding-top: 24px;
-
-  ${mq_lg} {
-    padding-top: 40px;
-  }
 `;
 
 const PaymentImage = styled.img`
-  width: 70%;
-  max-width: 260px;
+  position: absolute;
+  top: 11.4%;
+  left: 13.4%;
+  width: 73.1%;
   height: auto;
   border-radius: 28px;
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.2);
 
   ${mq_desktop} {
-    max-width: 448px;
-    width: 80%;
+    top: 64px;
+    left: 82.33px;
+    width: 448px;
+    height: 990px;
+    border-radius: 35px;
   }
 `;
 
@@ -283,6 +282,7 @@ export default {
   ScrollArea,
   Card,
   TextCard,
+  TitleDescriptionGroup,
   Chip,
   CardTitle,
   CardDescription,

--- a/apps/admin/src/pages/Landing/components/SolutionHighlight/index.tsx
+++ b/apps/admin/src/pages/Landing/components/SolutionHighlight/index.tsx
@@ -1,8 +1,9 @@
 import payment from '~/assets/landing-v2/payment.png';
 import promo1 from '~/assets/landing-v2/promo-1.png';
 import promo2 from '~/assets/landing-v2/promo-2.png';
+import { useDeviceWidth } from '~/hooks/useDeviceWidth';
 
-import { LANDING_COPY } from '../../constants';
+import { LANDING_BREAKPOINT, LANDING_COPY } from '../../constants';
 import { useVisibleSectionAtom } from '../../atoms/visibleSectionAtom';
 import Styled from './SolutionHighlight.styles';
 
@@ -18,6 +19,9 @@ const HIGHLIGHT_MEDIA = [
 
 const SolutionHighlight = () => {
   const { ref } = useVisibleSectionAtom('solution-highlight');
+  const deviceWidth = useDeviceWidth();
+  const isDesktop = deviceWidth >= LANDING_BREAKPOINT.desktop;
+  const isMobile = deviceWidth < LANDING_BREAKPOINT.tablet;
 
   return (
     <Styled.Section ref={ref} id="solution-highlight">
@@ -27,8 +31,14 @@ const SolutionHighlight = () => {
           <Styled.Card key={item.chip} variant={item.variant}>
             <Styled.TextCard>
               <Styled.Chip>{item.chip}</Styled.Chip>
-              <Styled.CardTitle>{item.title}</Styled.CardTitle>
-              <Styled.CardDescription>{item.description}</Styled.CardDescription>
+              <Styled.TitleDescriptionGroup>
+                <Styled.CardTitle>
+                  {isDesktop ? item.titleDesktop : item.title}
+                </Styled.CardTitle>
+                <Styled.CardDescription>
+                  {isMobile ? item.descriptionMobile : item.description}
+                </Styled.CardDescription>
+              </Styled.TitleDescriptionGroup>
             </Styled.TextCard>
             <Styled.ImgCard variant={item.variant}>{HIGHLIGHT_MEDIA[index]}</Styled.ImgCard>
           </Styled.Card>

--- a/apps/admin/src/pages/Landing/constants.ts
+++ b/apps/admin/src/pages/Landing/constants.ts
@@ -1,4 +1,10 @@
-export const mq_desktop = '@media (min-width: 1120px)';
+export const LANDING_BREAKPOINT = {
+  tablet: 768,
+  desktop: 1200,
+} as const;
+
+export const mq_lg = `@media (min-width: ${LANDING_BREAKPOINT.tablet}px)`;
+export const mq_desktop = `@media (min-width: ${LANDING_BREAKPOINT.desktop}px)`;
 
 export const LANDING_COLORS = {
   heroGradient: 'linear-gradient(180deg, #131343 0%, #020206 100%)',
@@ -59,14 +65,18 @@ export const LANDING_COPY = {
     items: [
       {
         chip: '공연 홍보',
-        title: '링크 하나로\n홍보 끝!',
+        title: '링크 하나로 홍보 끝!',
+        titleDesktop: '링크 하나로\n홍보 끝!',
         description: '일일이 정보를 첨부할 필요 없이, 링크만 공유하면 공연 홍보 완료',
+        descriptionMobile: '일일이 정보를 첨부할 필요 없이, 링크만 공유하면 홍보 완료',
         variant: 'light' as const,
       },
       {
         chip: '결제/발권',
         title: '다양한 결제 수단 지원',
+        titleDesktop: '다양한 결제 수단 지원',
         description: '번거로운 입금 대조 과정 없이 실시간으로 티켓 발권 가능',
+        descriptionMobile: '번거로운 입금 대조 과정 없이 실시간으로 티켓 발권 가능',
         variant: 'dark' as const,
       },
     ],


### PR DESCRIPTION
## Summary
랜딩페이지 2차 QA 피드백 반영
- 브레이크포인트를 데스크탑 1200px / 태블릿 768px / 모바일 375px 기준으로 통일
- SolutionHighlight 카드 텍스트(타이포·간격) 시안 기준 정리, 모바일/태블릿 제목 1줄, 데스크탑 이미지 절대 좌표로 정렬
- Header(모바일 24px 가변, 드롭다운 펼침 시 라인 제거, ‘앱 둘러보기’ 시안 적용) / Footer(모바일 24px 가변) 컨테이너 마진 정리
- Hero 이미지 잘림 해결, Problem 칩 이미지 opacity 1, FeatureCard 화살표 위치/사이즈, HowToUse Light(top -16px, opacity