### PR TITLE
Feat/hook test

### DIFF
--- a/apps/admin/src/components/ShareBanner/ShareBanner.integration.test.tsx
+++ b/apps/admin/src/components/ShareBanner/ShareBanner.integration.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+// 통합 테스트 목적:
+// 1) useShareBannerVisibility.isVisible 값에 따라 배너가 렌더링/비렌더링 되는지 검증
+// 2) 닫기 버튼 클릭 시 dismissForToday가 호출되는지 검증
+// 3) 공유 버튼 클릭 시 navigator.share가 호출되는지 검증
+import React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ShareBanner } from './index';
+import { useShareBannerVisibility } from '~/hooks/useShareBannerVisibility';
+
+vi.mock('~/hooks/useShareBannerVisibility', () => ({
+  useShareBannerVisibility: vi.fn(),
+}));
+
+vi.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@boolti/icon', () => ({
+  CloseIcon: () => <span>close-icon</span>,
+}));
+
+vi.mock('./ShareBanner.styles', () => ({
+  Container: (props: React.HTMLAttributes<HTMLDivElement>) => <div {...props} />,
+  CloseButton: (props: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" aria-label="배너 닫기" {...props} />
+  ),
+  Text: (props: React.HTMLAttributes<HTMLParagraphElement>) => <p {...props} />,
+  ShareButton: (
+    props: React.ButtonHTMLAttributes<HTMLButtonElement> & { colorTheme?: string; size?: string },
+  ) => {
+    const { colorTheme, size, ...domProps } = props;
+    void colorTheme;
+    void size;
+    return <button type={props.type ?? 'button'} {...domProps} />;
+  },
+}));
+
+const mockedUseShareBannerVisibility = vi.mocked(useShareBannerVisibility);
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ShareBanner integration', () => {
+  it('isVisible이 false면 배너를 렌더링하지 않는다', () => {
+    mockedUseShareBannerVisibility.mockReturnValue({
+      isVisible: false,
+      dismissForToday: vi.fn(),
+    });
+
+    render(<ShareBanner text="공유 배너" />);
+    expect(screen.queryByText('공유 배너')).toBeNull();
+  });
+
+  it('닫기 버튼 클릭 시 dismissForToday를 호출한다', () => {
+    const dismissForToday = vi.fn();
+    mockedUseShareBannerVisibility.mockReturnValue({
+      isVisible: true,
+      dismissForToday,
+    });
+
+    render(<ShareBanner text="공유 배너" />);
+    fireEvent.click(screen.getByLabelText('배너 닫기'));
+
+    expect(dismissForToday).toHaveBeenCalledTimes(1);
+  });
+
+  it('공유 버튼 클릭 시 navigator.share를 호출한다', async () => {
+    const dismissForToday = vi.fn();
+    mockedUseShareBannerVisibility.mockReturnValue({
+      isVisible: true,
+      dismissForToday,
+    });
+
+    const share = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', {
+      value: share,
+      configurable: true,
+    });
+
+    render(<ShareBanner text="공유 배너" />);
+    fireEvent.click(screen.getByRole('button', { name: '링크 공유' }));
+
+    expect(share).toHaveBeenCalledTimes(1);
+    expect(share).toHaveBeenCalledWith({
+      url: window.location.href,
+    });
+  });
+});

--- a/apps/admin/src/hooks/useBodyScrollLock.test.ts
+++ b/apps/admin/src/hooks/useBodyScrollLock.test.ts
@@ -1,0 +1,28 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useBodyScrollLock } from './useBodyScrollLock';
+
+describe('useBodyScrollLock', () => {
+  it('enabled=true면 body overflow를 hidden으로 잠근다', () => {
+    document.body.style.overflow = 'auto';
+    renderHook(() => useBodyScrollLock(true));
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  it('unmount 시 원래 overflow 값을 복원한다', () => {
+    document.body.style.overflow = 'scroll';
+    const { unmount } = renderHook(() => useBodyScrollLock(true));
+
+    expect(document.body.style.overflow).toBe('hidden');
+    unmount();
+    expect(document.body.style.overflow).toBe('scroll');
+  });
+
+  it('enabled=false면 overflow를 변경하지 않는다', () => {
+    document.body.style.overflow = 'visible';
+    renderHook(() => useBodyScrollLock(false));
+    expect(document.body.style.overflow).toBe('visible');
+  });
+});

--- a/apps/admin/src/hooks/useClipboardCopy.test.ts
+++ b/apps/admin/src/hooks/useClipboardCopy.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useClipboardCopy } from './useClipboardCopy';
+
+describe('useClipboardCopy', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('handleCopy 호출 시 copyFn이 실행되고 isCopied가 true가 된다', () => {
+    const copyFn = vi.fn();
+    const { result } = renderHook(() => useClipboardCopy(copyFn));
+
+    act(() => {
+      result.current.handleCopy();
+    });
+
+    expect(copyFn).toHaveBeenCalledTimes(1);
+    expect(result.current.isCopied).toBe(true);
+  });
+
+  it('기본 duration(2000ms) 경과 후 isCopied가 false로 돌아온다', () => {
+    const { result } = renderHook(() => useClipboardCopy(() => {}));
+
+    act(() => {
+      result.current.handleCopy();
+    });
+    expect(result.current.isCopied).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(result.current.isCopied).toBe(false);
+  });
+
+  it('커스텀 duration을 적용한다', () => {
+    const { result } = renderHook(() => useClipboardCopy(() => {}, 500));
+
+    act(() => {
+      result.current.handleCopy();
+    });
+    act(() => {
+      vi.advanceTimersByTime(499);
+    });
+    expect(result.current.isCopied).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current.isCopied).toBe(false);
+  });
+});

--- a/apps/admin/src/hooks/useCookie.test.ts
+++ b/apps/admin/src/hooks/useCookie.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+
+import useCookie from './useCookie';
+
+describe('useCookie', () => {
+  it('setCookie는 쿠키를 인코딩하여 저장한다', () => {
+    const { setCookie } = useCookie();
+
+    setCookie('popup', '한글 값');
+
+    expect(document.cookie).toContain('popup=');
+    expect(document.cookie).toContain(encodeURIComponent('한글 값'));
+  });
+
+  it('getCookie는 저장된 쿠키를 디코딩해 반환한다', () => {
+    const { setCookie, getCookie } = useCookie();
+
+    setCookie('token', 'abc 123');
+    expect(getCookie('token')).toBe('abc 123');
+  });
+
+  it('deleteCookie는 max-age=-1로 만료시킨다', () => {
+    const { setCookie, getCookie, deleteCookie } = useCookie();
+
+    setCookie('remove-me', 'value');
+    expect(getCookie('remove-me')).toBe('value');
+
+    deleteCookie('remove-me');
+    expect(getCookie('remove-me')).toBeNull();
+  });
+});

--- a/apps/admin/src/hooks/useDeviceWidth.test.ts
+++ b/apps/admin/src/hooks/useDeviceWidth.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useDeviceWidth } from './useDeviceWidth';
+
+describe('useDeviceWidth', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(window, 'innerWidth', {
+      value: 1200,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('초기값으로 window.innerWidth를 반환한다', () => {
+    const { result } = renderHook(() => useDeviceWidth());
+    expect(result.current).toBe(1200);
+  });
+
+  it('resize 이후 debounce(300ms) 경과 시 너비를 갱신한다', () => {
+    const { result } = renderHook(() => useDeviceWidth());
+
+    act(() => {
+      window.innerWidth = 640;
+      window.dispatchEvent(new Event('resize'));
+    });
+    expect(result.current).toBe(1200);
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(result.current).toBe(640);
+  });
+
+  it('debounce 구간에 resize가 연속 발생하면 마지막 width를 반영한다', () => {
+    const { result } = renderHook(() => useDeviceWidth());
+
+    act(() => {
+      window.innerWidth = 900;
+      window.dispatchEvent(new Event('resize'));
+      window.innerWidth = 700;
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(result.current).toBe(700);
+  });
+});

--- a/apps/admin/src/hooks/useIsMobile.test.ts
+++ b/apps/admin/src/hooks/useIsMobile.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useIsMobile } from './useIsMobile';
+import { useDeviceWidth } from './useDeviceWidth';
+import { useTheme } from '@emotion/react';
+
+vi.mock('./useDeviceWidth', () => ({
+  useDeviceWidth: vi.fn(),
+}));
+
+vi.mock('@emotion/react', () => ({
+  useTheme: vi.fn(),
+}));
+
+const mockedUseDeviceWidth = vi.mocked(useDeviceWidth);
+const mockedUseTheme = vi.mocked(useTheme);
+
+describe('useIsMobile', () => {
+  it('기기 너비가 모바일 breakpoint보다 작으면 true를 반환한다', () => {
+    mockedUseDeviceWidth.mockReturnValue(375);
+    mockedUseTheme.mockReturnValue({
+      breakpoint: { mobile: '768px' },
+    } as never);
+
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(true);
+  });
+
+  it('기기 너비가 모바일 breakpoint 이상이면 false를 반환한다', () => {
+    mockedUseDeviceWidth.mockReturnValue(1024);
+    mockedUseTheme.mockReturnValue({
+      breakpoint: { mobile: '768px' },
+    } as never);
+
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+  });
+});

--- a/apps/admin/src/hooks/usePopupDialog.test.tsx
+++ b/apps/admin/src/hooks/usePopupDialog.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Popup } from '@boolti/api';
+
+import usePopupDialog from './usePopupDialog';
+import { useDialog } from '@boolti/ui';
+import useCookie from './useCookie';
+
+vi.mock('@boolti/ui', () => ({
+  useDialog: vi.fn(),
+}));
+
+vi.mock('./useCookie', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('~/components/NoticePopupContent', () => ({
+  default: () => null,
+}));
+
+vi.mock('~/components/EventPopupContent', () => ({
+  default: () => null,
+}));
+
+const mockedUseDialog = vi.mocked(useDialog);
+const mockedUseCookie = vi.mocked(useCookie);
+
+const createPopup = (type: Popup['type']): Popup => ({
+  id: 1,
+  type,
+  eventUrl: 'https://example.com',
+  noticeTitle: '공지',
+  description: 'desc',
+  startDate: '2026-01-01T00:00:00.000Z',
+  endDate: '2026-12-31T23:59:59.999Z',
+});
+
+describe('usePopupDialog', () => {
+  let eventOpen: ReturnType<typeof vi.fn>;
+  let noticeOpen: ReturnType<typeof vi.fn>;
+  let callCount: number;
+
+  beforeEach(() => {
+    eventOpen = vi.fn();
+    noticeOpen = vi.fn();
+    callCount = 0;
+
+    mockedUseDialog.mockImplementation(() => {
+      callCount += 1;
+      if (callCount === 1) {
+        return { open: eventOpen, close: vi.fn() };
+      }
+      return { open: noticeOpen, close: vi.fn() };
+    });
+
+    mockedUseCookie.mockReturnValue({
+      getCookie: vi.fn(() => null),
+      setCookie: vi.fn(),
+      deleteCookie: vi.fn(),
+    });
+  });
+
+  it('popupData가 없으면 다이얼로그를 열지 않는다', () => {
+    renderHook(() => usePopupDialog(undefined));
+    expect(eventOpen).not.toHaveBeenCalled();
+    expect(noticeOpen).not.toHaveBeenCalled();
+  });
+
+  it('날짜 범위 밖이면 다이얼로그를 열지 않는다', () => {
+    const popup: Popup = {
+      ...createPopup('NOTICE'),
+      startDate: '2099-01-01T00:00:00.000Z',
+      endDate: '2099-12-31T23:59:59.999Z',
+    };
+    renderHook(() => usePopupDialog(popup));
+
+    expect(eventOpen).not.toHaveBeenCalled();
+    expect(noticeOpen).not.toHaveBeenCalled();
+  });
+
+  it('EVENT 팝업은 쿠키가 있으면 열지 않는다', () => {
+    const getCookie = vi.fn(() => '1');
+    mockedUseCookie.mockReturnValueOnce({
+      getCookie,
+      setCookie: vi.fn(),
+      deleteCookie: vi.fn(),
+    });
+    renderHook(() => usePopupDialog(createPopup('EVENT')));
+    expect(eventOpen).not.toHaveBeenCalled();
+  });
+
+  it('EVENT 팝업은 쿠키가 없으면 event 다이얼로그를 연다', () => {
+    mockedUseCookie.mockReturnValueOnce({
+      getCookie: vi.fn(() => null),
+      setCookie: vi.fn(),
+      deleteCookie: vi.fn(),
+    });
+    renderHook(() => usePopupDialog(createPopup('EVENT')));
+    expect(eventOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('NOTICE 팝업이면 notice 다이얼로그를 연다', () => {
+    renderHook(() => usePopupDialog(createPopup('NOTICE')));
+    expect(noticeOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('NOTICE 팝업은 쿠키 유무와 관계없이 notice 다이얼로그를 연다', () => {
+    mockedUseCookie.mockReturnValueOnce({
+      getCookie: vi.fn(() => '1'),
+      setCookie: vi.fn(),
+      deleteCookie: vi.fn(),
+    });
+
+    renderHook(() => usePopupDialog(createPopup('NOTICE')));
+    expect(noticeOpen).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/admin/src/hooks/usePopupDialog.test.tsx
+++ b/apps/admin/src/hooks/usePopupDialog.test.tsx
@@ -1,5 +1,4 @@
 // @vitest-environment jsdom
-import React from 'react';
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Popup } from '@boolti/api';
@@ -50,9 +49,9 @@ describe('usePopupDialog', () => {
     mockedUseDialog.mockImplementation(() => {
       callCount += 1;
       if (callCount === 1) {
-        return { open: eventOpen, close: vi.fn() };
+        return { id: 'event-dialog', isOpen: false, open: eventOpen, close: vi.fn() };
       }
-      return { open: noticeOpen, close: vi.fn() };
+      return { id: 'notice-dialog', isOpen: false, open: noticeOpen, close: vi.fn() };
     });
 
     mockedUseCookie.mockReturnValue({

--- a/apps/admin/src/hooks/useScrollDirection.test.ts
+++ b/apps/admin/src/hooks/useScrollDirection.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useScrollDirection } from './useScrollDirection';
+
+describe('useScrollDirection', () => {
+  beforeEach(() => {
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+    Object.defineProperty(window, 'scrollY', {
+      value: 0,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('초기 방향은 up이다', () => {
+    const { result } = renderHook(() => useScrollDirection());
+    expect(result.current).toBe('up');
+  });
+
+  it('스크롤이 증가하면 down으로 변경된다', () => {
+    const { result } = renderHook(() => useScrollDirection());
+
+    act(() => {
+      window.scrollY = 100;
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(result.current).toBe('down');
+  });
+
+  it('스크롤이 감소하면 up으로 변경된다', () => {
+    const { result } = renderHook(() => useScrollDirection());
+
+    act(() => {
+      window.scrollY = 120;
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(result.current).toBe('down');
+
+    act(() => {
+      window.scrollY = 20;
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(result.current).toBe('up');
+  });
+});

--- a/apps/admin/src/hooks/useShareBannerVisibility.test.ts
+++ b/apps/admin/src/hooks/useShareBannerVisibility.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useShareBannerVisibility } from './useShareBannerVisibility';
+import { useScrollDirection } from './useScrollDirection';
+
+vi.mock('./useScrollDirection', () => ({
+  useScrollDirection: vi.fn(),
+}));
+
+const mockedUseScrollDirection = vi.mocked(useScrollDirection);
+const DISMISS_KEY = 'share_banner_dismissed_at';
+
+describe('useShareBannerVisibility', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+    mockedUseScrollDirection.mockReturnValue('down');
+
+    Object.defineProperty(window, 'innerHeight', {
+      value: 1000,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(document.documentElement, 'scrollHeight', {
+      value: 2000,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(window, 'scrollY', {
+      value: 0,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('초기에는 표시 조건이 충족되지 않아 isVisible이 false다', () => {
+    const { result } = renderHook(() => useShareBannerVisibility());
+    expect(result.current.isVisible).toBe(false);
+  });
+
+  it('체류시간 10초 충족 시 isVisible이 true가 된다', () => {
+    const { result } = renderHook(() => useShareBannerVisibility());
+
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+
+    expect(result.current.isVisible).toBe(true);
+  });
+
+  it('스크롤 진행률이 50% 이상이면 isVisible이 true가 된다', () => {
+    const { result } = renderHook(() => useShareBannerVisibility());
+
+    act(() => {
+      window.scrollY = 500;
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(result.current.isVisible).toBe(true);
+  });
+
+  it('scrollDirection이 up이면 조건 충족이어도 표시하지 않는다', () => {
+    mockedUseScrollDirection.mockReturnValue('up');
+    const { result } = renderHook(() => useShareBannerVisibility());
+
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+
+    expect(result.current.isVisible).toBe(false);
+  });
+
+  it('스크롤 가능한 영역이 없으면 진행률 조건으로 표시되지 않는다', () => {
+    Object.defineProperty(document.documentElement, 'scrollHeight', {
+      value: 1000,
+      writable: true,
+      configurable: true,
+    });
+    const { result } = renderHook(() => useShareBannerVisibility());
+
+    act(() => {
+      window.scrollY = 500;
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(result.current.isVisible).toBe(false);
+  });
+
+  it('오늘 dismiss된 상태면 표시하지 않고 dismissForToday가 저장을 갱신한다', () => {
+    localStorage.setItem(DISMISS_KEY, Date.now().toString());
+    const { result } = renderHook(() => useShareBannerVisibility());
+
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+    expect(result.current.isVisible).toBe(false);
+
+    act(() => {
+      result.current.dismissForToday();
+    });
+    expect(localStorage.getItem(DISMISS_KEY)).not.toBeNull();
+    expect(result.current.isVisible).toBe(false);
+  });
+});


### PR DESCRIPTION
## 개요
admin 영역의 훅 테스트 커버리지를 보강하고, 훅 소비 컴포넌트(ShareBanner) 통합 테스트를 추가했습니다.
회귀 위험이 높은 타이머/브라우저 이벤트/스토리지/DOM side-effect 중심으로 검증 범위를 확장했습니다.

## 변경 사항

### 1) Hook Unit Test 추가
- `apps/admin/src/hooks/useShareBannerVisibility.test.ts`
- `apps/admin/src/hooks/usePopupDialog.test.tsx`
- `apps/admin/src/hooks/useDeviceWidth.test.ts`
- `apps/admin/src/hooks/useClipboardCopy.test.ts`
- `apps/admin/src/hooks/useBodyScrollLock.test.ts`
- `apps/admin/src/hooks/useIsMobile.test.ts`
- `apps/admin/src/hooks/useScrollDirection.test.ts`
- `apps/admin/src/hooks/useCookie.test.ts`

핵심 검증 포인트:
- 타이머/디바운스/스크롤 이벤트
- 쿠키/스토리지 side-effect
- 팝업 분기(EVENT/NOTICE, 기간, 쿠키 여부)
- 모바일 breakpoint 분기

### 2) Hook 소비 통합 테스트 추가
- `apps/admin/src/components/ShareBanner/ShareBanner.integration.test.tsx`

핵심 검증 포인트:
- `isVisible`에 따른 렌더링 분기
- 닫기 버튼 클릭 시 `dismissForToday` 호출
- 공유 버튼 클릭 시 `navigator.share` 호출

## 검증
- 실행 명령: `yarn workspace admin test`
- 결과: 전체 테스트 통과 (현재 브랜치 기준 green)

## 참고
- 이번 PR은 `develop` 대비 아래 파일만 추가되었습니다.
  - `apps/admin/src/components/ShareBanner/ShareBanner.integration.test.tsx`
  - `apps/admin/src/hooks/useBodyScrollLock.test.ts`
  - `apps/admin/src/hooks/useClipboardCopy.test.ts`
  - `apps/admin/src/hooks/useCookie.test.ts`
  - `apps/admin/src/hooks/useDeviceWidth.test.ts`
  - `apps/admin/src/hooks/useIsMobile.test.ts`
  - `apps/admin/src/hooks/usePopupDialog.test.tsx`
  - `apps/admin/src/hooks/useScrollDirection.test.ts`
  - `apps/admin/src/hooks/useShareBannerVisibility.test.ts`
