### PR TITLE
Feat/playwright test

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -4714,6 +4714,16 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["@playwright/test", [\
+      ["npm:1.59.1", {\
+        "packageLocation": "./.yarn/cache/@playwright-test-npm-1.59.1-8a59644a90-8c2d94a860.zip/node_modules/@playwright/test/",\
+        "packageDependencies": [\
+          ["@playwright/test", "npm:1.59.1"],\
+          ["playwright", "npm:1.59.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["@radix-ui/number", [\
       ["npm:1.0.1", {\
         "packageLocation": "./.yarn/cache/@radix-ui-number-npm-1.0.1-167c973d35-42e4870cd1.zip/node_modules/@radix-ui/number/",\
@@ -9566,6 +9576,7 @@ const RAW_RUNTIME_STATE =
           ["@emotion/babel-plugin", "npm:11.11.0"],\
           ["@emotion/react", "virtual:de80dc576383b2386358abc0e9fe49c00e3397fe355a0337462b73ab3115c2e557eb85784ee0fe776394cc11dd020b4e84dbbd75acf72ee6d54415d82d21f5c5#npm:11.11.3"],\
           ["@emotion/styled", "virtual:85869d3eba7afdb6f94c001c9503942ddc4354e881daf63c24e9d58366ea9f25c6bac2df65ae0f5266c54cd36fe68f0d9568da3a1ab62446405c98ac852f4431#npm:11.11.0"],\
+          ["@playwright/test", "npm:1.59.1"],\
           ["@react-pdf/renderer", "virtual:9845906954fdbefbb879db24fa8772d77a945dca59f459806df47a5b67245d4bc6502880b373cca7201062c81bea9f13f699f52de2004c037e79dbdbd5d97fb3#npm:3.4.4"],\
           ["@tanstack/react-table", "virtual:9845906954fdbefbb879db24fa8772d77a945dca59f459806df47a5b67245d4bc6502880b373cca7201062c81bea9f13f699f52de2004c037e79dbdbd5d97fb3#npm:8.12.0"],\
           ["@testing-library/dom", "npm:10.4.1"],\
@@ -13121,6 +13132,14 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["fsevents", [\
+      ["patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1", {\
+        "packageLocation": "./.yarn/unplugged/fsevents-patch-19706e7e35/node_modules/fsevents/",\
+        "packageDependencies": [\
+          ["fsevents", "patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"],\
+          ["node-gyp", "npm:10.0.1"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1", {\
         "packageLocation": "./.yarn/unplugged/fsevents-patch-6b67494872/node_modules/fsevents/",\
         "packageDependencies": [\
@@ -16924,6 +16943,26 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["pkg-dir", "npm:5.0.0"],\
           ["find-up", "npm:5.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["playwright", [\
+      ["npm:1.59.1", {\
+        "packageLocation": "./.yarn/cache/playwright-npm-1.59.1-8e8808a3f1-dfe38396e6.zip/node_modules/playwright/",\
+        "packageDependencies": [\
+          ["playwright", "npm:1.59.1"],\
+          ["fsevents", "patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"],\
+          ["playwright-core", "npm:1.59.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["playwright-core", [\
+      ["npm:1.59.1", {\
+        "packageLocation": "./.yarn/cache/playwright-core-npm-1.59.1-e63605649f-d41a74d968.zip/node_modules/playwright-core/",\
+        "packageDependencies": [\
+          ["playwright-core", "npm:1.59.1"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -4311,6 +4311,93 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["@inquirer/ansi", [\
+      ["npm:2.0.5", {\
+        "packageLocation": "./.yarn/cache/@inquirer-ansi-npm-2.0.5-8af5e6ad44-ad61532e5b.zip/node_modules/@inquirer/ansi/",\
+        "packageDependencies": [\
+          ["@inquirer/ansi", "npm:2.0.5"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@inquirer/confirm", [\
+      ["npm:6.0.12", {\
+        "packageLocation": "./.yarn/cache/@inquirer-confirm-npm-6.0.12-6d7d2fbcfc-36e9b1ef60.zip/node_modules/@inquirer/confirm/",\
+        "packageDependencies": [\
+          ["@inquirer/confirm", "npm:6.0.12"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:7e2aa39288a9bb75e6200124f1541c326c6028243dab00aa6c226e8828b558fe1489c4fd366fd37df54589d43d1f0c314c8cc2e624701deeaf35e2766fd42c47#npm:6.0.12", {\
+        "packageLocation": "./.yarn/__virtual__/@inquirer-confirm-virtual-e16cf0e037/0/cache/@inquirer-confirm-npm-6.0.12-6d7d2fbcfc-36e9b1ef60.zip/node_modules/@inquirer/confirm/",\
+        "packageDependencies": [\
+          ["@inquirer/confirm", "virtual:7e2aa39288a9bb75e6200124f1541c326c6028243dab00aa6c226e8828b558fe1489c4fd366fd37df54589d43d1f0c314c8cc2e624701deeaf35e2766fd42c47#npm:6.0.12"],\
+          ["@inquirer/core", "virtual:e16cf0e037e9dd550d338c6cad8ae802d855d5a39c64b1ef1a16eb54637cba28b15da825e30e4681240e412130a394c51848193b2f43a6d64a0eb127d1147206#npm:11.1.9"],\
+          ["@inquirer/type", "virtual:e16cf0e037e9dd550d338c6cad8ae802d855d5a39c64b1ef1a16eb54637cba28b15da825e30e4681240e412130a394c51848193b2f43a6d64a0eb127d1147206#npm:4.0.5"],\
+          ["@types/node", null]\
+        ],\
+        "packagePeers": [\
+          "@types/node"\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@inquirer/core", [\
+      ["npm:11.1.9", {\
+        "packageLocation": "./.yarn/cache/@inquirer-core-npm-11.1.9-6370fda053-f7b162ce5f.zip/node_modules/@inquirer/core/",\
+        "packageDependencies": [\
+          ["@inquirer/core", "npm:11.1.9"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:e16cf0e037e9dd550d338c6cad8ae802d855d5a39c64b1ef1a16eb54637cba28b15da825e30e4681240e412130a394c51848193b2f43a6d64a0eb127d1147206#npm:11.1.9", {\
+        "packageLocation": "./.yarn/__virtual__/@inquirer-core-virtual-c4f6012aa9/0/cache/@inquirer-core-npm-11.1.9-6370fda053-f7b162ce5f.zip/node_modules/@inquirer/core/",\
+        "packageDependencies": [\
+          ["@inquirer/core", "virtual:e16cf0e037e9dd550d338c6cad8ae802d855d5a39c64b1ef1a16eb54637cba28b15da825e30e4681240e412130a394c51848193b2f43a6d64a0eb127d1147206#npm:11.1.9"],\
+          ["@inquirer/ansi", "npm:2.0.5"],\
+          ["@inquirer/figures", "npm:2.0.5"],\
+          ["@inquirer/type", "virtual:e16cf0e037e9dd550d338c6cad8ae802d855d5a39c64b1ef1a16eb54637cba28b15da825e30e4681240e412130a394c51848193b2f43a6d64a0eb127d1147206#npm:4.0.5"],\
+          ["@types/node", null],\
+          ["cli-width", "npm:4.1.0"],\
+          ["fast-wrap-ansi", "npm:0.2.0"],\
+          ["mute-stream", "npm:3.0.0"],\
+          ["signal-exit", "npm:4.1.0"]\
+        ],\
+        "packagePeers": [\
+          "@types/node"\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@inquirer/figures", [\
+      ["npm:2.0.5", {\
+        "packageLocation": "./.yarn/cache/@inquirer-figures-npm-2.0.5-6cb995d689-139671b88f.zip/node_modules/@inquirer/figures/",\
+        "packageDependencies": [\
+          ["@inquirer/figures", "npm:2.0.5"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@inquirer/type", [\
+      ["npm:4.0.5", {\
+        "packageLocation": "./.yarn/cache/@inquirer-type-npm-4.0.5-c68ee3257f-390edb0fd1.zip/node_modules/@inquirer/type/",\
+        "packageDependencies": [\
+          ["@inquirer/type", "npm:4.0.5"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:e16cf0e037e9dd550d338c6cad8ae802d855d5a39c64b1ef1a16eb54637cba28b15da825e30e4681240e412130a394c51848193b2f43a6d64a0eb127d1147206#npm:4.0.5", {\
+        "packageLocation": "./.yarn/__virtual__/@inquirer-type-virtual-e0de942d8b/0/cache/@inquirer-type-npm-4.0.5-c68ee3257f-390edb0fd1.zip/node_modules/@inquirer/type/",\
+        "packageDependencies": [\
+          ["@inquirer/type", "virtual:e16cf0e037e9dd550d338c6cad8ae802d855d5a39c64b1ef1a16eb54637cba28b15da825e30e4681240e412130a394c51848193b2f43a6d64a0eb127d1147206#npm:4.0.5"],\
+          ["@types/node", null]\
+        ],\
+        "packagePeers": [\
+          "@types/node"\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["@isaacs/cliui", [\
       ["npm:8.0.2", {\
         "packageLocation": "./.yarn/cache/@isaacs-cliui-npm-8.0.2-f4364666d5-b1bf42535d.zip/node_modules/@isaacs/cliui/",\
@@ -4629,6 +4716,21 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["@mswjs/interceptors", [\
+      ["npm:0.41.8", {\
+        "packageLocation": "./.yarn/cache/@mswjs-interceptors-npm-0.41.8-4b2fae0579-6ffe97fc7a.zip/node_modules/@mswjs/interceptors/",\
+        "packageDependencies": [\
+          ["@mswjs/interceptors", "npm:0.41.8"],\
+          ["@open-draft/deferred-promise", "npm:2.2.0"],\
+          ["@open-draft/logger", "npm:0.3.0"],\
+          ["@open-draft/until", "npm:2.1.0"],\
+          ["is-node-process", "npm:1.2.0"],\
+          ["outvariant", "npm:1.4.3"],\
+          ["strict-event-emitter", "npm:0.5.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["@ndelangen/get-tarball", [\
       ["npm:3.0.9", {\
         "packageLocation": "./.yarn/cache/@ndelangen-get-tarball-npm-3.0.9-c4692f22a4-d66e76c6c9.zip/node_modules/@ndelangen/get-tarball/",\
@@ -4692,6 +4794,42 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@npmcli/fs", "npm:3.1.0"],\
           ["semver", "npm:7.5.4"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@open-draft/deferred-promise", [\
+      ["npm:2.2.0", {\
+        "packageLocation": "./.yarn/cache/@open-draft-deferred-promise-npm-2.2.0-adf396dc9f-eafc1b1d0f.zip/node_modules/@open-draft/deferred-promise/",\
+        "packageDependencies": [\
+          ["@open-draft/deferred-promise", "npm:2.2.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/@open-draft-deferred-promise-npm-3.0.0-f8ff16b581-4dd697e554.zip/node_modules/@open-draft/deferred-promise/",\
+        "packageDependencies": [\
+          ["@open-draft/deferred-promise", "npm:3.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@open-draft/logger", [\
+      ["npm:0.3.0", {\
+        "packageLocation": "./.yarn/cache/@open-draft-logger-npm-0.3.0-12b03e55aa-90010647b2.zip/node_modules/@open-draft/logger/",\
+        "packageDependencies": [\
+          ["@open-draft/logger", "npm:0.3.0"],\
+          ["is-node-process", "npm:1.2.0"],\
+          ["outvariant", "npm:1.4.3"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@open-draft/until", [\
+      ["npm:2.1.0", {\
+        "packageLocation": "./.yarn/cache/@open-draft-until-npm-2.1.0-e27da33c52-61d3f99718.zip/node_modules/@open-draft/until/",\
+        "packageDependencies": [\
+          ["@open-draft/until", "npm:2.1.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -8858,6 +8996,25 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["@types/set-cookie-parser", [\
+      ["npm:2.4.10", {\
+        "packageLocation": "./.yarn/cache/@types-set-cookie-parser-npm-2.4.10-d2555d8830-010b0c582e.zip/node_modules/@types/set-cookie-parser/",\
+        "packageDependencies": [\
+          ["@types/set-cookie-parser", "npm:2.4.10"],\
+          ["@types/node", "npm:20.11.16"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@types/statuses", [\
+      ["npm:2.0.6", {\
+        "packageLocation": "./.yarn/cache/@types-statuses-npm-2.0.6-ef1f12f3e4-dd88c220b0.zip/node_modules/@types/statuses/",\
+        "packageDependencies": [\
+          ["@types/statuses", "npm:2.0.6"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["@types/unist", [\
       ["npm:2.0.10", {\
         "packageLocation": "./.yarn/cache/@types-unist-npm-2.0.10-f9b9ac478e-5f247dc222.zip/node_modules/@types/unist/",\
@@ -9594,6 +9751,7 @@ const RAW_RUNTIME_STATE =
           ["jsdom", "virtual:9845906954fdbefbb879db24fa8772d77a945dca59f459806df47a5b67245d4bc6502880b373cca7201062c81bea9f13f699f52de2004c037e79dbdbd5d97fb3#npm:26.1.0"],\
           ["jwt-decode", "npm:4.0.0"],\
           ["lodash.debounce", "npm:4.0.8"],\
+          ["msw", "virtual:9845906954fdbefbb879db24fa8772d77a945dca59f459806df47a5b67245d4bc6502880b373cca7201062c81bea9f13f699f52de2004c037e79dbdbd5d97fb3#npm:2.14.2"],\
           ["qrcode.react", "virtual:9845906954fdbefbb879db24fa8772d77a945dca59f459806df47a5b67245d4bc6502880b373cca7201062c81bea9f13f699f52de2004c037e79dbdbd5d97fb3#npm:3.1.0"],\
           ["quill", "npm:2.0.3"],\
           ["react", "npm:18.2.0"],\
@@ -10783,6 +10941,27 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["cli-width", [\
+      ["npm:4.1.0", {\
+        "packageLocation": "./.yarn/cache/cli-width-npm-4.1.0-c08b53be83-1fbd564135.zip/node_modules/cli-width/",\
+        "packageDependencies": [\
+          ["cli-width", "npm:4.1.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["cliui", [\
+      ["npm:8.0.1", {\
+        "packageLocation": "./.yarn/cache/cliui-npm-8.0.1-3b029092cf-4bda0f09c3.zip/node_modules/cliui/",\
+        "packageDependencies": [\
+          ["cliui", "npm:8.0.1"],\
+          ["string-width", "npm:4.2.3"],\
+          ["strip-ansi", "npm:6.0.1"],\
+          ["wrap-ansi", "npm:7.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["clone", [\
       ["npm:1.0.4", {\
         "packageLocation": "./.yarn/cache/clone-npm-1.0.4-a610fcbcf9-2176952b36.zip/node_modules/clone/",\
@@ -11026,6 +11205,13 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/cookie-npm-0.5.0-e2d58a161a-c01ca3ef8d.zip/node_modules/cookie/",\
         "packageDependencies": [\
           ["cookie", "npm:0.5.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:1.1.1", {\
+        "packageLocation": "./.yarn/cache/cookie-npm-1.1.1-881103ddeb-79c4ddc0fc.zip/node_modules/cookie/",\
+        "packageDependencies": [\
+          ["cookie", "npm:1.1.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -12769,6 +12955,35 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["fast-string-truncated-width", [\
+      ["npm:3.0.3", {\
+        "packageLocation": "./.yarn/cache/fast-string-truncated-width-npm-3.0.3-1f742a6cd9-043b866339.zip/node_modules/fast-string-truncated-width/",\
+        "packageDependencies": [\
+          ["fast-string-truncated-width", "npm:3.0.3"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["fast-string-width", [\
+      ["npm:3.0.2", {\
+        "packageLocation": "./.yarn/cache/fast-string-width-npm-3.0.2-f4e7c6c8bc-c8822d1753.zip/node_modules/fast-string-width/",\
+        "packageDependencies": [\
+          ["fast-string-width", "npm:3.0.2"],\
+          ["fast-string-truncated-width", "npm:3.0.3"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["fast-wrap-ansi", [\
+      ["npm:0.2.0", {\
+        "packageLocation": "./.yarn/cache/fast-wrap-ansi-npm-0.2.0-11e4628564-c0eb6debee.zip/node_modules/fast-wrap-ansi/",\
+        "packageDependencies": [\
+          ["fast-wrap-ansi", "npm:0.2.0"],\
+          ["fast-string-width", "npm:3.0.2"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["fastest-stable-stringify", [\
       ["npm:2.0.2", {\
         "packageLocation": "./.yarn/cache/fastest-stable-stringify-npm-2.0.2-f2a059d214-abbe5ff48f.zip/node_modules/fastest-stable-stringify/",\
@@ -13207,6 +13422,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["get-caller-file", [\
+      ["npm:2.0.5", {\
+        "packageLocation": "./.yarn/cache/get-caller-file-npm-2.0.5-80e8a86305-c6c7b60271.zip/node_modules/get-caller-file/",\
+        "packageDependencies": [\
+          ["get-caller-file", "npm:2.0.5"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["get-func-name", [\
       ["npm:2.0.2", {\
         "packageLocation": "./.yarn/cache/get-func-name-npm-2.0.2-409dbe3703-89830fd076.zip/node_modules/get-func-name/",\
@@ -13485,6 +13709,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["graphql", [\
+      ["npm:16.13.2", {\
+        "packageLocation": "./.yarn/cache/graphql-npm-16.13.2-dd8254da13-64e822a0a0.zip/node_modules/graphql/",\
+        "packageDependencies": [\
+          ["graphql", "npm:16.13.2"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["gunzip-maybe", [\
       ["npm:1.4.2", {\
         "packageLocation": "./.yarn/cache/gunzip-maybe-npm-1.4.2-97df376cb9-42798a8061.zip/node_modules/gunzip-maybe/",\
@@ -13626,6 +13859,17 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["hast-util-whitespace", "npm:3.0.0"],\
           ["@types/hast", "npm:3.0.4"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["headers-polyfill", [\
+      ["npm:5.0.1", {\
+        "packageLocation": "./.yarn/cache/headers-polyfill-npm-5.0.1-5c80cb3378-c269730a88.zip/node_modules/headers-polyfill/",\
+        "packageDependencies": [\
+          ["headers-polyfill", "npm:5.0.1"],\
+          ["@types/set-cookie-parser", "npm:2.4.10"],\
+          ["set-cookie-parser", "npm:3.1.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -14251,6 +14495,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/is-negative-zero-npm-2.0.2-0adac91f15-eda024c158.zip/node_modules/is-negative-zero/",\
         "packageDependencies": [\
           ["is-negative-zero", "npm:2.0.2"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["is-node-process", [\
+      ["npm:1.2.0", {\
+        "packageLocation": "./.yarn/cache/is-node-process-npm-1.2.0-34f2abe8e1-5b24fda677.zip/node_modules/is-node-process/",\
+        "packageDependencies": [\
+          ["is-node-process", "npm:1.2.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -16104,11 +16357,60 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["msw", [\
+      ["npm:2.14.2", {\
+        "packageLocation": "./.yarn/unplugged/msw-virtual-7e2aa39288/node_modules/msw/",\
+        "packageDependencies": [\
+          ["msw", "npm:2.14.2"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:9845906954fdbefbb879db24fa8772d77a945dca59f459806df47a5b67245d4bc6502880b373cca7201062c81bea9f13f699f52de2004c037e79dbdbd5d97fb3#npm:2.14.2", {\
+        "packageLocation": "./.yarn/unplugged/msw-virtual-7e2aa39288/node_modules/msw/",\
+        "packageDependencies": [\
+          ["msw", "virtual:9845906954fdbefbb879db24fa8772d77a945dca59f459806df47a5b67245d4bc6502880b373cca7201062c81bea9f13f699f52de2004c037e79dbdbd5d97fb3#npm:2.14.2"],\
+          ["@inquirer/confirm", "virtual:7e2aa39288a9bb75e6200124f1541c326c6028243dab00aa6c226e8828b558fe1489c4fd366fd37df54589d43d1f0c314c8cc2e624701deeaf35e2766fd42c47#npm:6.0.12"],\
+          ["@mswjs/interceptors", "npm:0.41.8"],\
+          ["@open-draft/deferred-promise", "npm:3.0.0"],\
+          ["@types/statuses", "npm:2.0.6"],\
+          ["@types/typescript", null],\
+          ["cookie", "npm:1.1.1"],\
+          ["graphql", "npm:16.13.2"],\
+          ["headers-polyfill", "npm:5.0.1"],\
+          ["is-node-process", "npm:1.2.0"],\
+          ["outvariant", "npm:1.4.3"],\
+          ["path-to-regexp", "npm:6.3.0"],\
+          ["picocolors", "npm:1.1.1"],\
+          ["rettime", "npm:0.11.11"],\
+          ["statuses", "npm:2.0.2"],\
+          ["strict-event-emitter", "npm:0.5.1"],\
+          ["tough-cookie", "npm:6.0.1"],\
+          ["type-fest", "npm:5.6.0"],\
+          ["typescript", "patch:typescript@npm%3A5.3.3#optional!builtin<compat/typescript>::version=5.3.3&hash=e012d7"],\
+          ["until-async", "npm:3.0.2"],\
+          ["yargs", "npm:17.7.2"]\
+        ],\
+        "packagePeers": [\
+          "@types/typescript",\
+          "typescript"\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["mutation-observer", [\
       ["npm:1.0.3", {\
         "packageLocation": "./.yarn/cache/mutation-observer-npm-1.0.3-fa3b236d74-2f010fdec4.zip/node_modules/mutation-observer/",\
         "packageDependencies": [\
           ["mutation-observer", "npm:1.0.3"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["mute-stream", [\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/mute-stream-npm-3.0.0-b51769acce-12cdb36a10.zip/node_modules/mute-stream/",\
+        "packageDependencies": [\
+          ["mute-stream", "npm:3.0.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -16578,6 +16880,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["outvariant", [\
+      ["npm:1.4.3", {\
+        "packageLocation": "./.yarn/cache/outvariant-npm-1.4.3-192f951f81-5976ca7740.zip/node_modules/outvariant/",\
+        "packageDependencies": [\
+          ["outvariant", "npm:1.4.3"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["p-limit", [\
       ["npm:2.3.0", {\
         "packageLocation": "./.yarn/cache/p-limit-npm-2.3.0-94a0310039-8da01ac53e.zip/node_modules/p-limit/",\
@@ -16799,6 +17110,13 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/path-to-regexp-npm-0.1.7-2605347373-50a1ddb1af.zip/node_modules/path-to-regexp/",\
         "packageDependencies": [\
           ["path-to-regexp", "npm:0.1.7"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:6.3.0", {\
+        "packageLocation": "./.yarn/cache/path-to-regexp-npm-6.3.0-ee2cdde576-73b67f4638.zip/node_modules/path-to-regexp/",\
+        "packageDependencies": [\
+          ["path-to-regexp", "npm:6.3.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -19724,6 +20042,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["require-directory", [\
+      ["npm:2.1.1", {\
+        "packageLocation": "./.yarn/cache/require-directory-npm-2.1.1-8608aee50b-83aa76a7bc.zip/node_modules/require-directory/",\
+        "packageDependencies": [\
+          ["require-directory", "npm:2.1.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["require-from-string", [\
       ["npm:2.0.2", {\
         "packageLocation": "./.yarn/cache/require-from-string-npm-2.0.2-8557e0db12-aaa267e0c5.zip/node_modules/require-from-string/",\
@@ -19795,6 +20122,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/retry-npm-0.12.0-72ac7fb4cc-59933e8501.zip/node_modules/retry/",\
         "packageDependencies": [\
           ["retry", "npm:0.12.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["rettime", [\
+      ["npm:0.11.11", {\
+        "packageLocation": "./.yarn/cache/rettime-npm-0.11.11-a494d8bd51-021fc9d987.zip/node_modules/rettime/",\
+        "packageDependencies": [\
+          ["rettime", "npm:0.11.11"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -20091,6 +20427,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/set-blocking-npm-2.0.0-49e2cffa24-9f8c1b2d80.zip/node_modules/set-blocking/",\
         "packageDependencies": [\
           ["set-blocking", "npm:2.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["set-cookie-parser", [\
+      ["npm:3.1.0", {\
+        "packageLocation": "./.yarn/cache/set-cookie-parser-npm-3.1.0-f66fecf7c7-7465e389ff.zip/node_modules/set-cookie-parser/",\
+        "packageDependencies": [\
+          ["set-cookie-parser", "npm:3.1.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -20478,6 +20823,13 @@ const RAW_RUNTIME_STATE =
           ["statuses", "npm:2.0.1"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:2.0.2", {\
+        "packageLocation": "./.yarn/cache/statuses-npm-2.0.2-2d84c63b8c-a9947d98ad.zip/node_modules/statuses/",\
+        "packageDependencies": [\
+          ["statuses", "npm:2.0.2"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["std-env", [\
@@ -20557,6 +20909,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/stream-shift-npm-1.0.3-c1c29210c7-939cd1051c.zip/node_modules/stream-shift/",\
         "packageDependencies": [\
           ["stream-shift", "npm:1.0.3"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["strict-event-emitter", [\
+      ["npm:0.5.1", {\
+        "packageLocation": "./.yarn/cache/strict-event-emitter-npm-0.5.1-8414bf36b3-f5228a6e6b.zip/node_modules/strict-event-emitter/",\
+        "packageDependencies": [\
+          ["strict-event-emitter", "npm:0.5.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -20963,6 +21324,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["tagged-tag", [\
+      ["npm:1.0.0", {\
+        "packageLocation": "./.yarn/cache/tagged-tag-npm-1.0.0-80e0c0061d-91d25c9ffb.zip/node_modules/tagged-tag/",\
+        "packageDependencies": [\
+          ["tagged-tag", "npm:1.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["tar", [\
       ["npm:6.2.0", {\
         "packageLocation": "./.yarn/cache/tar-npm-6.2.0-3eb25205a7-02ca064a1a.zip/node_modules/tar/",\
@@ -21190,6 +21560,14 @@ const RAW_RUNTIME_STATE =
           ["tldts-core", "npm:6.1.86"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:7.0.30", {\
+        "packageLocation": "./.yarn/cache/tldts-npm-7.0.30-e815b3f846-c36f7b480f.zip/node_modules/tldts/",\
+        "packageDependencies": [\
+          ["tldts", "npm:7.0.30"],\
+          ["tldts-core", "npm:7.0.30"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["tldts-core", [\
@@ -21197,6 +21575,13 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/tldts-core-npm-6.1.86-540def5eb4-8133c29375.zip/node_modules/tldts-core/",\
         "packageDependencies": [\
           ["tldts-core", "npm:6.1.86"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:7.0.30", {\
+        "packageLocation": "./.yarn/cache/tldts-core-npm-7.0.30-ed52aa351a-e3cd730e96.zip/node_modules/tldts-core/",\
+        "packageDependencies": [\
+          ["tldts-core", "npm:7.0.30"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -21262,6 +21647,14 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["tough-cookie", "npm:5.1.2"],\
           ["tldts", "npm:6.1.86"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:6.0.1", {\
+        "packageLocation": "./.yarn/cache/tough-cookie-npm-6.0.1-7a26930694-ec70bd6b12.zip/node_modules/tough-cookie/",\
+        "packageDependencies": [\
+          ["tough-cookie", "npm:6.0.1"],\
+          ["tldts", "npm:7.0.30"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -21513,6 +21906,14 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/type-fest-npm-2.19.0-918b953248-a5a7ecf2e6.zip/node_modules/type-fest/",\
         "packageDependencies": [\
           ["type-fest", "npm:2.19.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:5.6.0", {\
+        "packageLocation": "./.yarn/cache/type-fest-npm-5.6.0-daf055db8b-5468a8ffda.zip/node_modules/type-fest/",\
+        "packageDependencies": [\
+          ["type-fest", "npm:5.6.0"],\
+          ["tagged-tag", "npm:1.0.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -21849,6 +22250,15 @@ const RAW_RUNTIME_STATE =
           ["chokidar", "npm:3.5.3"],\
           ["webpack-sources", "npm:3.2.3"],\
           ["webpack-virtual-modules", "npm:0.6.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["until-async", [\
+      ["npm:3.0.2", {\
+        "packageLocation": "./.yarn/cache/until-async-npm-3.0.2-1afeb8e787-61c8b03895.zip/node_modules/until-async/",\
+        "packageDependencies": [\
+          ["until-async", "npm:3.0.2"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -22733,6 +23143,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["y18n", [\
+      ["npm:5.0.8", {\
+        "packageLocation": "./.yarn/cache/y18n-npm-5.0.8-5f3a0a7e62-4df2842c36.zip/node_modules/y18n/",\
+        "packageDependencies": [\
+          ["y18n", "npm:5.0.8"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["yallist", [\
       ["npm:3.1.1", {\
         "packageLocation": "./.yarn/cache/yallist-npm-3.1.1-a568a556b4-c66a5c46bc.zip/node_modules/yallist/",\
@@ -22754,6 +23173,31 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/yaml-npm-1.10.2-0e780aebdf-5c28b9eb7a.zip/node_modules/yaml/",\
         "packageDependencies": [\
           ["yaml", "npm:1.10.2"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["yargs", [\
+      ["npm:17.7.2", {\
+        "packageLocation": "./.yarn/cache/yargs-npm-17.7.2-80b62638e1-ccd7e723e6.zip/node_modules/yargs/",\
+        "packageDependencies": [\
+          ["yargs", "npm:17.7.2"],\
+          ["cliui", "npm:8.0.1"],\
+          ["escalade", "npm:3.1.1"],\
+          ["get-caller-file", "npm:2.0.5"],\
+          ["require-directory", "npm:2.1.1"],\
+          ["string-width", "npm:4.2.3"],\
+          ["y18n", "npm:5.0.8"],\
+          ["yargs-parser", "npm:21.1.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["yargs-parser", [\
+      ["npm:21.1.1", {\
+        "packageLocation": "./.yarn/cache/yargs-parser-npm-21.1.1-8fdc003314-f84b5e4816.zip/node_modules/yargs-parser/",\
+        "packageDependencies": [\
+          ["yargs-parser", "npm:21.1.1"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/apps/admin/.gitignore
+++ b/apps/admin/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.last-run.json

--- a/apps/admin/e2e/functional/auth-routing.e2e.spec.ts
+++ b/apps/admin/e2e/functional/auth-routing.e2e.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test';
+
+import { prepareE2EContext } from '../helpers/msw';
+
+test.describe('Auth routing guard', () => {
+  test.beforeEach(async ({ page }) => {
+    await prepareE2EContext(page);
+  });
+
+  test('비로그인 + 일반 브라우저는 /home 접근 시 /login으로 이동한다', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+    });
+
+    await page.goto('/home');
+    await expect(page).toHaveURL(/\/login$/);
+    await expect(page.getByText('로그인')).toBeVisible();
+  });
+
+  test('로그인 상태는 /home 접근이 허용된다', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('accessToken', 'access-token');
+      localStorage.setItem('refreshToken', 'refresh-token');
+    });
+
+    await page.goto('/home');
+    await expect(page).toHaveURL(/\/home$/);
+    await expect(page.getByText('로그인')).toHaveCount(0);
+  });
+
+  test('비로그인이라도 webview userAgent면 /home 접근이 허용된다', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+      Object.defineProperty(window.navigator, 'userAgent', {
+        configurable: true,
+        value: 'Mozilla/5.0 BOOLTI/ANDROID',
+      });
+    });
+
+    await page.goto('/home');
+    await expect(page).toHaveURL(/\/home$/);
+  });
+});

--- a/apps/admin/e2e/functional/auth-routing.e2e.spec.ts
+++ b/apps/admin/e2e/functional/auth-routing.e2e.spec.ts
@@ -15,31 +15,7 @@ test.describe('Auth routing guard', () => {
 
     await page.goto('/home');
     await expect(page).toHaveURL(/\/login$/);
-    await expect(page.getByText('로그인')).toBeVisible();
-  });
-
-  test('로그인 상태는 /home 접근이 허용된다', async ({ page }) => {
-    await page.addInitScript(() => {
-      localStorage.setItem('accessToken', 'access-token');
-      localStorage.setItem('refreshToken', 'refresh-token');
-    });
-
-    await page.goto('/home');
-    await expect(page).toHaveURL(/\/home$/);
-    await expect(page.getByText('로그인')).toHaveCount(0);
-  });
-
-  test('비로그인이라도 webview userAgent면 /home 접근이 허용된다', async ({ page }) => {
-    await page.addInitScript(() => {
-      localStorage.removeItem('accessToken');
-      localStorage.removeItem('refreshToken');
-      Object.defineProperty(window.navigator, 'userAgent', {
-        configurable: true,
-        value: 'Mozilla/5.0 BOOLTI/ANDROID',
-      });
-    });
-
-    await page.goto('/home');
-    await expect(page).toHaveURL(/\/home$/);
+    await expect(page.getByRole('heading', { name: '로그인' })).toBeVisible();
+    await expect(page.getByRole('button', { name: '카카오톡으로 시작하기' })).toBeVisible();
   });
 });

--- a/apps/admin/e2e/functional/prequestion-response-flow.e2e.spec.ts
+++ b/apps/admin/e2e/functional/prequestion-response-flow.e2e.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from '@playwright/test';
+
+import { prepareE2EContext } from '../helpers/msw';
+
+test.describe('Pre-question response flow', () => {
+  test.beforeEach(async ({ page }) => {
+    await prepareE2EContext(page);
+    await page.addInitScript(() => {
+      localStorage.setItem('accessToken', 'access-token');
+      localStorage.setItem('refreshToken', 'refresh-token');
+    });
+  });
+
+  test('응답 확인 탭에서 참여자별 응답/검색 플로우가 동작한다', async ({ page }) => {
+    await page.goto('/show/1/pre-question');
+    await expect(page.getByText('응답 확인')).toBeVisible();
+
+    await page.getByText('응답 확인').click();
+    await page.getByRole('button', { name: '참여자별 응답' }).click();
+
+    await expect(page.getByText('홍길동', { exact: true })).toBeVisible();
+    await page.getByPlaceholder('참여자명 검색').fill('홍길동');
+    await page.waitForTimeout(400);
+    await expect(page.getByText('홍길동', { exact: true })).toBeVisible();
+  });
+
+  test('검색 결과가 없으면 빈 상태 메시지가 노출된다', async ({ page }) => {
+    await page.goto('/show/1/pre-question');
+    await page.getByText('응답 확인').click();
+    await page.getByRole('button', { name: '참여자별 응답' }).click();
+
+    await page.getByPlaceholder('참여자명 검색').fill('없는이름');
+    await page.waitForTimeout(400);
+
+    await expect(page.getByText('검색 결과가 없어요.')).toBeVisible();
+  });
+});

--- a/apps/admin/e2e/functional/settlement-request-flow.e2e.spec.ts
+++ b/apps/admin/e2e/functional/settlement-request-flow.e2e.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '@playwright/test';
+
+import { prepareE2EContext } from '../helpers/msw';
+
+test.describe('Settlement request flow', () => {
+  test.beforeEach(async ({ page }) => {
+    await prepareE2EContext(page);
+    await page.addInitScript(() => {
+      localStorage.setItem('accessToken', 'access-token');
+      localStorage.setItem('refreshToken', 'refresh-token');
+    });
+  });
+
+  test('동의 체크 전 비활성, 체크 후 활성화되고 요청이 전송된다', async ({ page }) => {
+    await page.goto('/show/1/settlement');
+    const submitButton = page.getByRole('button', { name: '정산 요청하기' });
+    await expect(submitButton).toBeDisabled();
+
+    await page.getByText('정산 내역 및 안내사항을 모두 확인하였으며 정산을 요청합니다.').click();
+    await expect(submitButton).toBeEnabled();
+    await submitButton.click();
+
+    await expect(page.getByText('정산을 요청했습니다')).toBeVisible();
+  });
+
+  test('요청 실패 시 에러 토스트가 노출된다', async ({ page }) => {
+    await page.goto('/show/1/settlement');
+    await page.evaluate(() => {
+      localStorage.setItem('__E2E_SCENARIO__', 'settlement-request-fail');
+    });
+    await page.getByText('정산 내역 및 안내사항을 모두 확인하였으며 정산을 요청합니다.').click();
+    await page.getByRole('button', { name: '정산 요청하기' }).click();
+
+    await expect(page.getByText('정산 요청에 실패했습니다. 잠시 후에 다시 시도해주세요.')).toBeVisible();
+  });
+});

--- a/apps/admin/e2e/helpers/msw.ts
+++ b/apps/admin/e2e/helpers/msw.ts
@@ -7,6 +7,6 @@ export const prepareE2EContext = async (page: Page, scenario: string = 'default'
   }, scenario);
 
   await page.goto('/');
-  await page.waitForTimeout(300);
+  await page.waitForFunction(() => window.__E2E_MSW_READY__ === true, null, { timeout: 5000 });
   await page.reload();
 };

--- a/apps/admin/e2e/helpers/msw.ts
+++ b/apps/admin/e2e/helpers/msw.ts
@@ -1,0 +1,12 @@
+import type { Page } from '@playwright/test';
+
+export const prepareE2EContext = async (page: Page, scenario: string = 'default') => {
+  await page.addInitScript((currentScenario) => {
+    (window as Window & { __ENABLE_E2E_MSW__?: boolean }).__ENABLE_E2E_MSW__ = true;
+    localStorage.setItem('__E2E_SCENARIO__', currentScenario);
+  }, scenario);
+
+  await page.goto('/');
+  await page.waitForTimeout(300);
+  await page.reload();
+};

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -12,7 +12,7 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:e2e": "playwright test -c playwright.config.ts",
+    "test:e2e:functional": "playwright test -c playwright.config.ts",
     "test:e2e:ui": "playwright test -c playwright.config.ts --ui"
   },
   "dependencies": {
@@ -67,8 +67,14 @@
     "@types/react-dom": "^18.2.17",
     "@vitejs/plugin-react": "^4.2.1",
     "jsdom": "^26.1.0",
+    "msw": "^2.14.2",
     "typescript": "^5.2.2",
     "vite": "^5.0.8",
     "vitest": "^2.1.9"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -11,7 +11,9 @@
     "type-check": "tsc --noEmit",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test -c playwright.config.ts",
+    "test:e2e:ui": "playwright test -c playwright.config.ts --ui"
   },
   "dependencies": {
     "@boolti/api": "*",
@@ -56,6 +58,7 @@
     "@boolti/eslint-config": "*",
     "@boolti/typescript-config": "*",
     "@emotion/babel-plugin": "^11.11.0",
+    "@playwright/test": "^1.54.1",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.0.1",
     "@types/js-cookie": "^3.0.6",

--- a/apps/admin/playwright.config.ts
+++ b/apps/admin/playwright.config.ts
@@ -4,15 +4,13 @@ export default defineConfig({
   testDir: './e2e/functional',
   timeout: 30_000,
   use: {
-    baseURL: 'https://127.0.0.1:4173',
-    ignoreHTTPSErrors: true,
+    baseURL: 'http://127.0.0.1:4173',
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
   },
   webServer: {
-    command: 'VITE_BASE_API_URL=https://127.0.0.1:4173/ yarn workspace admin dev --host 127.0.0.1 --port 4173',
-    url: 'https://127.0.0.1:4173',
-    ignoreHTTPSErrors: true,
+    command: 'VITE_E2E_MSW=true VITE_BASE_API_URL=http://127.0.0.1:4173/ yarn workspace admin dev --host 127.0.0.1 --port 4173',
+    url: 'http://127.0.0.1:4173',
     reuseExistingServer: true,
     timeout: 120_000,
   },

--- a/apps/admin/playwright.config.ts
+++ b/apps/admin/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e/functional',
+  timeout: 30_000,
+  use: {
+    baseURL: 'https://127.0.0.1:4173',
+    ignoreHTTPSErrors: true,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  webServer: {
+    command: 'VITE_BASE_API_URL=https://127.0.0.1:4173/ yarn workspace admin dev --host 127.0.0.1 --port 4173',
+    url: 'https://127.0.0.1:4173',
+    ignoreHTTPSErrors: true,
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: 'desktop',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1280, height: 800 },
+      },
+    },
+  ],
+});

--- a/apps/admin/public/mockServiceWorker.js
+++ b/apps/admin/public/mockServiceWorker.js
@@ -1,0 +1,349 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.14.2'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/apps/admin/src/App.auth-routing.integration.test.tsx
+++ b/apps/admin/src/App.auth-routing.integration.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+// 통합 테스트 목적:
+// 1) 비로그인 + 일반 브라우저면 /home 접근 시 /login으로 리다이렉트되는지 검증
+// 2) 로그인 상태면 /home 접근이 허용되는지 검증
+// 3) 비로그인이라도 webview면 /home 접근이 허용되는지 검증
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockIsLogin = vi.fn<() => boolean>();
+const mockCheckIsWebView = vi.fn<() => boolean>();
+
+vi.mock('~/atoms/useAuthAtom', () => ({
+  useAuthAtom: () => ({
+    isLogin: mockIsLogin,
+  }),
+}));
+
+vi.mock('@boolti/bridge', () => ({
+  checkIsWebView: () => mockCheckIsWebView(),
+}));
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return {
+    ...actual,
+    ScrollRestoration: () => null,
+  };
+});
+
+import PrivateRoute from './routes/PrivateRoute';
+
+const renderWithRoute = (isLogin: boolean, isWebView: boolean) => {
+  mockIsLogin.mockReturnValue(isLogin);
+  mockCheckIsWebView.mockReturnValue(isWebView);
+
+  render(
+    <MemoryRouter initialEntries={['/home']}>
+      <Routes>
+        <Route path="/login" element={<div>로그인 페이지</div>} />
+        <Route element={<PrivateRoute />}>
+          <Route path="/home" element={<div>홈 페이지</div>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+};
+
+describe('PrivateRoute integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.scrollTo = vi.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('비로그인 + 일반 브라우저면 /login으로 이동한다', async () => {
+    renderWithRoute(false, false);
+
+    expect(await screen.findByText('로그인 페이지')).toBeTruthy();
+    expect(screen.queryByText('홈 페이지')).toBeNull();
+  });
+
+  it('로그인 상태면 /home 접근이 허용된다', async () => {
+    renderWithRoute(true, false);
+
+    expect(await screen.findByText('홈 페이지')).toBeTruthy();
+    expect(screen.queryByText('로그인 페이지')).toBeNull();
+  });
+
+  it('비로그인이라도 webview면 /home 접근이 허용된다', async () => {
+    renderWithRoute(false, true);
+
+    expect(await screen.findByText('홈 페이지')).toBeTruthy();
+    expect(screen.queryByText('로그인 페이지')).toBeNull();
+  });
+});

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -19,7 +19,6 @@ import {
 
 import AuthErrorBoundary from './components/ErrorBoundary/AuthErrorBoundary';
 import { PATH } from './constants/routes';
-import { useAuthAtom } from './atoms/useAuthAtom';
 import GlobalErrorBoundary from './components/ErrorBoundary/GlobalErrorBoundary';
 import {
   LandingPage,
@@ -46,10 +45,10 @@ import ShowReservationPage from './pages/ShowReservationPage';
 import ShowSettlementPage from './pages/ShowSettlementPage';
 import ShowEnterancePage from './pages/ShowEnterancePage';
 import { initVConsole } from './utils/vConsole';
-import { checkIsWebView } from '@boolti/bridge';
 import { X_NCP_APIGW_API_KEY_ID } from './constants/ncp';
 import { IS_PRODUCTION_PHASE } from './constants/phase';
 import WebView from './pages/WebView';
+import PrivateRoute from './routes/PrivateRoute';
 
 setDefaultOptions({ locale: ko });
 
@@ -109,23 +108,6 @@ const publicRoutes = [
     ],
   },
 ];
-
-const PrivateRoute = () => {
-  const { isLogin } = useAuthAtom();
-
-  if (!isLogin() && !checkIsWebView()) {
-    return <Navigate to={PATH.LOGIN} replace />;
-  }
-
-  return (
-    <>
-      <ScrollRestoration />
-      <Suspense fallback={null}>
-        <Outlet />
-      </Suspense>
-    </>
-  );
-};
 
 const privateRoutes = [
   {

--- a/apps/admin/src/components/ShowPreQuestion/ResponseTab/ResponseTab.integration.test.tsx
+++ b/apps/admin/src/components/ShowPreQuestion/ResponseTab/ResponseTab.integration.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+// 통합 테스트 목적:
+// 1) 응답자가 0명일 때 EmptyView가 노출되는지 검증
+// 2) 질문별/참여자별 뷰 전환이 동작하는지 검증
+// 3) 모바일 질문별 뷰에서 정렬 토글이 최신/오래된 순으로 전환되는지 검증
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { forwardRef, type ReactNode } from 'react';
+
+import type { PreQuestionItem } from '@boolti/api/src/types';
+
+const mockIsMobile = vi.fn();
+
+vi.mock('@boolti/api', () => ({
+  usePreQuestionAnswersList: () => [{ data: { content: [], totalElements: 0 }, isLoading: false, isFetching: false }],
+  usePreQuestionParticipants: () => ({ data: { content: [] } }),
+  usePreQuestionParticipantDetail: () => ({ data: null }),
+  useSalesTicketTypesSummary: () => ({ data: [] }),
+}));
+
+vi.mock('~/hooks/useIsMobile', () => ({
+  useIsMobile: () => mockIsMobile(),
+}));
+
+vi.mock('./EmptyView', () => ({
+  default: () => <div>EmptyView</div>,
+}));
+
+vi.mock('./QuestionResponseView', () => ({
+  default: () => <div>QuestionResponseView</div>,
+}));
+
+vi.mock('./ParticipantResponseView', () => ({
+  default: () => <div>ParticipantResponseView</div>,
+}));
+
+vi.mock('~/components/TicketNameFilter', () => ({
+  default: () => <div>TicketNameFilter</div>,
+}));
+
+vi.mock('./ResponseTab.styles', () => ({
+  default: {
+    Container: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    HeaderContainer: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    SegmentButtonContainer: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    SegmentButton: ({
+      children,
+      onClick,
+    }: {
+      children: ReactNode;
+      onClick?: () => void;
+    }) => (
+      <button type="button" onClick={onClick}>
+        {children}
+      </button>
+    ),
+    SortContainer: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    MobileQuestionSortToggle: ({
+      children,
+      onClick,
+    }: {
+      children: ReactNode;
+      onClick?: () => void;
+    }) => (
+      <button type="button" onClick={onClick}>
+        {children}
+      </button>
+    ),
+    SortDropdown: forwardRef<HTMLDivElement, { children: ReactNode }>(({ children }, ref) => (
+      <div ref={ref}>{children}</div>
+    )),
+    SortButton: ({
+      children,
+      onClick,
+    }: {
+      children: ReactNode;
+      onClick?: () => void;
+    }) => (
+      <button type="button" onClick={onClick}>
+        {children}
+      </button>
+    ),
+    SortMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    SortMenuItem: ({
+      children,
+      onClick,
+    }: {
+      children: ReactNode;
+      onClick?: () => void;
+    }) => (
+      <button type="button" onClick={onClick}>
+        {children}
+      </button>
+    ),
+  },
+}));
+
+import ResponseTab from './index';
+
+const questions: PreQuestionItem[] = [
+  { id: 1, question: '질문 1', isRequired: true, sequence: 1 },
+];
+
+describe('ResponseTab integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsMobile.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('응답자가 0명이면 EmptyView를 렌더링한다', () => {
+    render(<ResponseTab showId={1} questions={questions} totalRespondentCount={0} />);
+    expect(screen.getByText('EmptyView')).toBeTruthy();
+  });
+
+  it('질문별/참여자별 탭 전환이 동작한다', () => {
+    render(<ResponseTab showId={1} questions={questions} totalRespondentCount={3} />);
+
+    expect(screen.getByText('QuestionResponseView')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: '참여자별 응답' }));
+    expect(screen.getByText('ParticipantResponseView')).toBeTruthy();
+  });
+
+  it('모바일 질문별 뷰에서 정렬 토글 시 레이블이 전환된다', () => {
+    mockIsMobile.mockReturnValue(true);
+    render(<ResponseTab showId={1} questions={questions} totalRespondentCount={3} />);
+
+    const latestButtons = screen.getAllByRole('button', { name: /최신 순/ });
+    const sortToggle = latestButtons[latestButtons.length - 1];
+    expect(sortToggle).toBeTruthy();
+    if (!sortToggle) {
+      return;
+    }
+    fireEvent.click(sortToggle);
+    expect(screen.getByRole('button', { name: /오래된 순/ })).toBeTruthy();
+  });
+});

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -6,10 +6,17 @@ const bootstrap = async () => {
   const enableE2EMSW = (window as Window & { __ENABLE_E2E_MSW__?: boolean }).__ENABLE_E2E_MSW__ === true;
   if (enableE2EMSW) {
     const { worker } = await import('./mocks/browser');
-    await worker.start({
-      onUnhandledRequest: 'bypass',
-      serviceWorker: { url: '/mockServiceWorker.js' },
-    });
+    void worker
+      .start({
+        onUnhandledRequest: 'bypass',
+        serviceWorker: { url: '/mockServiceWorker.js' },
+      })
+      .then(() => {
+        window.__E2E_MSW_READY__ = true;
+      })
+      .catch(() => {
+        window.__E2E_MSW_READY__ = false;
+      });
   }
 
   ReactDOM.createRoot(document.getElementById('root')!).render(<App />);

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -2,4 +2,17 @@ import ReactDOM from 'react-dom/client';
 
 import App from './App';
 
-ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+const bootstrap = async () => {
+  const enableE2EMSW = (window as Window & { __ENABLE_E2E_MSW__?: boolean }).__ENABLE_E2E_MSW__ === true;
+  if (enableE2EMSW) {
+    const { worker } = await import('./mocks/browser');
+    await worker.start({
+      onUnhandledRequest: 'bypass',
+      serviceWorker: { url: '/mockServiceWorker.js' },
+    });
+  }
+
+  ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+};
+
+void bootstrap();

--- a/apps/admin/src/mocks/browser.ts
+++ b/apps/admin/src/mocks/browser.ts
@@ -1,0 +1,5 @@
+import { setupWorker } from 'msw/browser';
+
+import { handlers } from './handlers';
+
+export const worker = setupWorker(...handlers);

--- a/apps/admin/src/mocks/handlers.ts
+++ b/apps/admin/src/mocks/handlers.ts
@@ -1,0 +1,199 @@
+import { HttpResponse, http, type JsonBodyType } from 'msw';
+
+const emptyPage = {
+  content: [],
+  empty: true,
+  first: true,
+  last: true,
+  number: 0,
+  numberOfElements: 0,
+  size: 100,
+  totalElements: 0,
+  totalPages: 0,
+  pageable: {
+    offset: 0,
+    pageNumber: 0,
+    pageSize: 100,
+    paged: true,
+    unpaged: false,
+    sort: { sorted: false, unsorted: true, empty: true },
+  },
+  sort: { sorted: false, unsorted: true, empty: true },
+};
+
+const json = (body: JsonBodyType, status = 200) => HttpResponse.json(body, { status });
+
+const getScenario = () => window.localStorage.getItem('__E2E_SCENARIO__') ?? 'default';
+
+const SHOW_NAME = '기능 테스트 공연';
+const PARTICIPANT_NAME = '홍길동';
+const TICKET_NAME = '일반 티켓';
+const COMMON_TIME = '2026-05-01T10:00:00.000Z';
+
+const popupHome = {
+  id: 1,
+  type: 'NOTICE',
+  description: '테스트 공지',
+  noticeTitle: '공지',
+  eventUrl: 'https://example.com',
+  startDate: '2099-01-01T00:00:00.000Z',
+  endDate: '2099-12-31T23:59:59.999Z',
+};
+
+const showDetail = {
+  id: 1,
+  name: SHOW_NAME,
+  date: '2099-12-31T12:00:00.000Z',
+};
+
+const participantSummary = {
+  reservationId: 501,
+  reservationName: PARTICIPANT_NAME,
+  userId: 100,
+  salesTicketTypeId: 10,
+  salesTicketTypeName: TICKET_NAME,
+  ticketCount: 1,
+  answeredAt: COMMON_TIME,
+};
+
+export const handlers = [
+  http.all('*/web/papi/v1/popup/HOME', () => json(popupHome)),
+  http.get('*/web/v1/host/shows/1', () => json(showDetail)),
+  http.get('*/web/v1/users/me', () =>
+    json({
+      id: 10,
+      imgPath: null,
+      nickname: '테스터',
+      userCode: 'TESTER001',
+    }),
+  ),
+  http.get('*/web/v1/host/shows', () => json([])),
+  http.get('*/web/v1/host/users/me/summaries', () =>
+    json({
+      nickname: '테스터',
+      profileImagePath: null,
+      userCode: 'TESTER001',
+    }),
+  ),
+  http.get('*/web/v1/shows/1/hosts/me', () =>
+    json({
+      id: 1,
+      hostName: '테스터',
+      imagePath: null,
+      type: 'MAIN',
+    }),
+  ),
+  http.get('*/web/v1/host/shows/1/sales-infos', () => json({ salesStartDateTime: null, salesEndDateTime: null })),
+  http.get('*/web/v1/host/shows/1/settlement-infos', () =>
+    json({
+      bankAccount: '카카오뱅크 123-456',
+      idCardPhotoFile: { url: 'https://example.com/id.pdf', fileName: 'id.pdf' },
+      settlementBankAccountPhotoFile: { url: 'https://example.com/bank.pdf', fileName: 'bank.pdf' },
+    }),
+  ),
+  http.get('*/web/v1/host/shows/1/settlement-events/last', () =>
+    json({ settlementEventType: 'SEND', triggeredAt: '2026-05-01T00:00:00.000Z' }),
+  ),
+  http.get('*/web/v1/shows/1/settlement-summaries', () =>
+    json({
+      salesAmount: 1200000,
+      actual: null,
+      expected: { fee: 120000, settlementAmount: 1080000 },
+    }),
+  ),
+  http.all('*/web/v1/host/settlement-banners', ({ request }) => {
+    if (request.method === 'POST') return json({});
+    return json([{ showId: 1, bannerType: 'REQUIRED', showName: SHOW_NAME }]);
+  }),
+  http.get('*/web/v1/host/shows/1/settlement-statements/last/file', () =>
+    new HttpResponse('%PDF-1.4\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF', {
+      status: 200,
+      headers: { 'content-type': 'application/pdf' },
+    }),
+  ),
+  http.post('*/web/v1/host/shows/1/settlement-request', () => {
+    if (getScenario() === 'settlement-request-fail') {
+      return json({ message: 'fail' }, 500);
+    }
+    return json({});
+  }),
+  http.get('*/web/v1/host/shows/1/pre-questions', () =>
+    json({
+      preQuestions: [
+        {
+          id: 101,
+          question: '관람 전 확인하고 싶은 내용이 있나요?',
+          description: '자유 입력',
+          isRequired: true,
+          sequence: 1,
+        },
+      ],
+      totalRespondentCount: 2,
+    }),
+  ),
+  http.get('*/web/v1/host/shows/1/sales-ticket-types/summary', () => json([{ id: 10, ticketType: 'SALE', ticketName: '일반 티켓' }])),
+  http.get('*/web/v1/host/shows/1/pre-question-answers/questions/101', () =>
+    json({
+      ...emptyPage,
+      content: [
+        {
+          id: 1,
+          preQuestionId: 101,
+          userId: 100,
+          reservationName: PARTICIPANT_NAME,
+          salesTicketTypeId: 10,
+          salesTicketTypeName: TICKET_NAME,
+          reservationId: 501,
+          ticketCount: 1,
+          answer: '현장 주차 가능 여부',
+          createdAt: COMMON_TIME,
+          modifiedAt: COMMON_TIME,
+        },
+      ],
+      empty: false,
+      numberOfElements: 1,
+      totalElements: 1,
+      totalPages: 1,
+    }),
+  ),
+  http.get('*/web/v1/host/shows/1/pre-question-answers/participants/501', () =>
+    json({
+      reservationId: 501,
+      userId: 100,
+      reservationName: PARTICIPANT_NAME,
+      salesTicketTypeId: 10,
+      salesTicketTypeName: TICKET_NAME,
+      ticketCount: 1,
+      createdAt: COMMON_TIME,
+      modifiedAt: COMMON_TIME,
+      answers: [
+        {
+          preQuestionId: 101,
+          question: '관람 전 확인하고 싶은 내용이 있나요?',
+          description: '자유 입력',
+          isRequired: true,
+          answer: '현장 주차 가능 여부',
+          sequence: 1,
+          createdAt: COMMON_TIME,
+          modifiedAt: COMMON_TIME,
+        },
+      ],
+    }),
+  ),
+  http.get('*/web/v1/host/shows/1/pre-question-answers/participants', ({ request }) => {
+    const url = new URL(request.url);
+    const reservationName = url.searchParams.get('reservationName');
+    const noMatchedReservation = !!reservationName && reservationName !== PARTICIPANT_NAME;
+
+    return json({
+      ...emptyPage,
+      content: noMatchedReservation ? [] : [participantSummary],
+      empty: noMatchedReservation,
+      numberOfElements: noMatchedReservation ? 0 : 1,
+      totalElements: noMatchedReservation ? 0 : 1,
+      totalPages: noMatchedReservation ? 0 : 1,
+    });
+  }),
+  http.all('*/web/*', () => json({})),
+  http.all('*/sa-api/*', () => json({})),
+];

--- a/apps/admin/src/pages/HomePage/HomePage.integration.test.tsx
+++ b/apps/admin/src/pages/HomePage/HomePage.integration.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+// 통합 테스트 목적:
+// 1) HomePage가 HOME 팝업 데이터를 조회하는지 검증
+// 2) 조회된 popupData를 usePopupDialog에 전달하는지 검증
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Popup } from '@boolti/api';
+import type { ReactNode } from 'react';
+
+const mockUsePopup = vi.fn();
+const mockUsePopupDialog = vi.fn();
+
+vi.mock('@boolti/api', () => ({
+  queryKeys: {
+    user: {
+      summary: { queryKey: ['user', 'summary'] },
+    },
+  },
+  useLogout: () => ({ mutateAsync: vi.fn() }),
+  usePopup: (...args: unknown[]) => mockUsePopup(...args),
+  useQueryClient: () => ({ removeQueries: vi.fn() }),
+  useSettlementBanners: () => ({ data: [] }),
+  useShowList: () => ({ data: [], isLoading: false }),
+  useUserProfile: () => ({ data: null, isLoading: false }),
+}));
+
+vi.mock('@boolti/ui', () => ({
+  Footer: () => <div>Footer</div>,
+  useConfirm: () => vi.fn().mockResolvedValue(false),
+  useDialog: () => ({ id: 'dialog', isOpen: false, open: vi.fn(), close: vi.fn() }),
+}));
+
+vi.mock('@boolti/bridge', () => ({
+  checkIsWebView: () => false,
+}));
+
+vi.mock('~/components/Header', () => ({
+  default: () => <div>Header</div>,
+}));
+
+vi.mock('~/components/Layout', () => ({
+  default: ({
+    children,
+    header,
+    headerMenu,
+    banner,
+  }: {
+    children: ReactNode;
+    header?: ReactNode;
+    headerMenu?: ReactNode;
+    banner?: ReactNode;
+  }) => (
+    <div>
+      {header}
+      {headerMenu}
+      {banner}
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('~/components/ShowList', () => ({
+  default: () => <div>ShowList</div>,
+}));
+
+vi.mock('~/components/UserProfile', () => ({
+  default: () => <div>UserProfile</div>,
+}));
+
+vi.mock('~/components/ProfileDropdown', () => ({
+  default: () => <button type="button">ProfileDropdown</button>,
+}));
+
+vi.mock('~/components/SettingDialogContent', () => ({
+  default: () => <div>SettingDialogContent</div>,
+}));
+
+vi.mock('~/components/ShowTypeSelectDialogContent', () => ({
+  default: () => <div>ShowTypeSelectDialogContent</div>,
+}));
+
+vi.mock('~/atoms/useAuthAtom', () => ({
+  useAuthAtom: () => ({ removeToken: vi.fn() }),
+}));
+
+vi.mock('~/hooks/usePopupDialog', () => ({
+  default: (...args: unknown[]) => mockUsePopupDialog(...args),
+}));
+
+vi.mock('./HomePage.styles', () => ({
+  default: {
+    Logo: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    ProfileDropdown: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    ProfileDropdownMobile: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    HeaderMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    HeaderMenuItemButton: ({
+      children,
+      onClick,
+    }: {
+      children: ReactNode;
+      onClick?: () => void | Promise<void>;
+    }) => (
+      <button type="button" onClick={onClick}>
+        {children}
+      </button>
+    ),
+    BannerContainer: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    Banner: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    BannerDescription: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    BannerShowTitle: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+    BannerLink: ({ children }: { children: ReactNode }) => <a href="#">{children}</a>,
+    Container: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  },
+}));
+
+import HomePage from './index';
+
+describe('HomePage integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('HOME 팝업 데이터를 조회하고 usePopupDialog에 전달한다', () => {
+    const popupData = {
+      id: 11,
+      type: 'EVENT',
+      description: 'banner',
+      noticeTitle: 'title',
+      eventUrl: 'https://example.com',
+      startDate: '2026-01-01T00:00:00.000Z',
+      endDate: '2026-12-31T23:59:59.999Z',
+    } satisfies Popup;
+
+    mockUsePopup.mockReturnValue({ data: popupData });
+
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>,
+    );
+
+    expect(mockUsePopup).toHaveBeenCalledWith('HOME');
+    expect(mockUsePopupDialog).toHaveBeenCalledWith(popupData);
+  });
+});

--- a/apps/admin/src/pages/Landing/Landing.integration.test.tsx
+++ b/apps/admin/src/pages/Landing/Landing.integration.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+// 통합 테스트 목적:
+// 1) LandingPage가 HOME 팝업 데이터를 조회하는지 검증
+// 2) 조회된 popupData를 usePopupDialog에 전달하는지 검증
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Popup } from '@boolti/api';
+import type { ReactNode } from 'react';
+
+const mockUsePopup = vi.fn();
+const mockUsePopupDialog = vi.fn();
+
+vi.mock('@boolti/api', () => ({
+  usePopup: (...args: unknown[]) => mockUsePopup(...args),
+}));
+
+vi.mock('@boolti/ui', () => ({
+  Footer: () => <div>Footer</div>,
+}));
+
+vi.mock('~/hooks/usePopupDialog', () => ({
+  default: (...args: unknown[]) => mockUsePopupDialog(...args),
+}));
+
+vi.mock('./components', () => ({
+  Header: () => <div>Header</div>,
+  Hero: () => <div>Hero</div>,
+  HowToUse: () => <div>HowToUse</div>,
+  Problem: () => <div>Problem</div>,
+  SolutionFeatures: () => <div>SolutionFeatures</div>,
+  SolutionHighlight: () => <div>SolutionHighlight</div>,
+}));
+
+vi.mock('./LandingPage.styles', () => ({
+  default: {
+    Container: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    FooterContainer: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  },
+}));
+
+import LandingPage from './index';
+
+describe('LandingPage integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('HOME 팝업 데이터를 조회하고 usePopupDialog에 전달한다', () => {
+    const popupData = {
+      id: 22,
+      type: 'NOTICE',
+      description: 'notice',
+      noticeTitle: '공지',
+      eventUrl: 'https://example.com',
+      startDate: '2026-01-01T00:00:00.000Z',
+      endDate: '2026-12-31T23:59:59.999Z',
+    } satisfies Popup;
+
+    mockUsePopup.mockReturnValue({ data: popupData });
+
+    render(<LandingPage />);
+
+    expect(mockUsePopup).toHaveBeenCalledWith('HOME');
+    expect(mockUsePopupDialog).toHaveBeenCalledWith(popupData);
+  });
+});

--- a/apps/admin/src/routes/PrivateRoute.tsx
+++ b/apps/admin/src/routes/PrivateRoute.tsx
@@ -1,0 +1,25 @@
+import { checkIsWebView } from '@boolti/bridge';
+import { Navigate, Outlet, ScrollRestoration } from 'react-router-dom';
+import { Suspense } from 'react';
+
+import { useAuthAtom } from '~/atoms/useAuthAtom';
+import { PATH } from '~/constants/routes';
+
+const PrivateRoute = () => {
+  const { isLogin } = useAuthAtom();
+
+  if (!isLogin() && !checkIsWebView()) {
+    return <Navigate to={PATH.LOGIN} replace />;
+  }
+
+  return (
+    <>
+      <ScrollRestoration />
+      <Suspense fallback={null}>
+        <Outlet />
+      </Suspense>
+    </>
+  );
+};
+
+export default PrivateRoute;

--- a/apps/admin/src/vite-env.d.ts
+++ b/apps/admin/src/vite-env.d.ts
@@ -11,4 +11,5 @@ interface ImportMeta {
 
 interface Window {
   __ENABLE_E2E_MSW__?: boolean;
+  __E2E_MSW_READY__?: boolean;
 }

--- a/apps/admin/src/vite-env.d.ts
+++ b/apps/admin/src/vite-env.d.ts
@@ -8,3 +8,7 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+interface Window {
+  __ENABLE_E2E_MSW__?: boolean;
+}

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -1,8 +1,11 @@
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  test: {
+    exclude: ['e2e/**'],
+  },
   resolve: {
     alias: [{ find: '~', replacement: '/src' }],
   },

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -1,6 +1,8 @@
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vitest/config';
 
+const isE2EMsw = process.env.VITE_E2E_MSW === 'true';
+
 // https://vitejs.dev/config/
 export default defineConfig({
   test: {
@@ -12,11 +14,13 @@ export default defineConfig({
   server: {
     port: 8080,
     cors: false,
-    host: 'dev.boolti.in',
-    https: {
-      key: './dev.boolti.in-key.pem',
-      cert: './dev.boolti.in.pem',
-    },
+    host: isE2EMsw ? '127.0.0.1' : 'dev.boolti.in',
+    https: isE2EMsw
+      ? undefined
+      : {
+          key: './dev.boolti.in-key.pem',
+          cert: './dev.boolti.in.pem',
+        },
   },
   plugins: [
     react({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2728,6 +2728,67 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/ansi@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "@inquirer/ansi@npm:2.0.5"
+  checksum: 10c0/ad61532e5bb47473e3d987c32d4015499a8ce5f4f86e46467e8e672fc52670beb303905d6b324e453935a61671f59f3b9b1b6a1edbbe1f64085e2bb87735e295
+  languageName: node
+  linkType: hard
+
+"@inquirer/confirm@npm:^6.0.11":
+  version: 6.0.12
+  resolution: "@inquirer/confirm@npm:6.0.12"
+  dependencies:
+    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/type": "npm:^4.0.5"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/36e9b1ef60e08562f07bcbcd78ba0a681b2fa3e5f54fa5e12303fc5982e8ba875ed782c24161e2295028b2b404ba690e841837303d16eeeb28df7aa9eb8aa835
+  languageName: node
+  linkType: hard
+
+"@inquirer/core@npm:^11.1.9":
+  version: 11.1.9
+  resolution: "@inquirer/core@npm:11.1.9"
+  dependencies:
+    "@inquirer/ansi": "npm:^2.0.5"
+    "@inquirer/figures": "npm:^2.0.5"
+    "@inquirer/type": "npm:^4.0.5"
+    cli-width: "npm:^4.1.0"
+    fast-wrap-ansi: "npm:^0.2.0"
+    mute-stream: "npm:^3.0.0"
+    signal-exit: "npm:^4.1.0"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/f7b162ce5f67fb75aab00a3668fdd8c8629aec790087840ea66ee8ead6009ab2066bec9cbf5bcc394ccdf130e6139051d6bace334b3a66c4f05349585213172c
+  languageName: node
+  linkType: hard
+
+"@inquirer/figures@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "@inquirer/figures@npm:2.0.5"
+  checksum: 10c0/139671b88f33f059aec85ed3fdf464999115573350c6dea61141adc1cfd43d14742b6cb68150c2ca9baf5a1bae618f990ed89b4430ae768d415bbd19944c56df
+  languageName: node
+  linkType: hard
+
+"@inquirer/type@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "@inquirer/type@npm:4.0.5"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/390edb0fd1f027f9c8dc26bac28486d38bbde6c19974ef1588ea187f54a2cb58db639ebca31fa81a8fe4a4e84c2f0953ab3f5a6768ba86649368c5e806148a6f
+  languageName: node
+  linkType: hard
+
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -2978,6 +3039,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mswjs/interceptors@npm:^0.41.3":
+  version: 0.41.8
+  resolution: "@mswjs/interceptors@npm:0.41.8"
+  dependencies:
+    "@open-draft/deferred-promise": "npm:^2.2.0"
+    "@open-draft/logger": "npm:^0.3.0"
+    "@open-draft/until": "npm:^2.0.0"
+    is-node-process: "npm:^1.2.0"
+    outvariant: "npm:^1.4.3"
+    strict-event-emitter: "npm:^0.5.1"
+  checksum: 10c0/6ffe97fc7a84acc3d25464542b061e2525b6964c694c4fb325b91d01b61229124c457d5af75cf5eeb96969741769cc104d5d2d11e26d6dbae995aa9398fd9a7e
+  languageName: node
+  linkType: hard
+
 "@ndelangen/get-tarball@npm:^3.0.7":
   version: 3.0.9
   resolution: "@ndelangen/get-tarball@npm:3.0.9"
@@ -3035,6 +3110,37 @@ __metadata:
   dependencies:
     semver: "npm:^7.3.5"
   checksum: 10c0/162b4a0b8705cd6f5c2470b851d1dc6cd228c86d2170e1769d738c1fbb69a87160901411c3c035331e9e99db72f1f1099a8b734bf1637cc32b9a5be1660e4e1e
+  languageName: node
+  linkType: hard
+
+"@open-draft/deferred-promise@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@open-draft/deferred-promise@npm:2.2.0"
+  checksum: 10c0/eafc1b1d0fc8edb5e1c753c5e0f3293410b40dde2f92688211a54806d4136887051f39b98c1950370be258483deac9dfd17cf8b96557553765198ef2547e4549
+  languageName: node
+  linkType: hard
+
+"@open-draft/deferred-promise@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@open-draft/deferred-promise@npm:3.0.0"
+  checksum: 10c0/4dd697e55495e436be9536413cc9975e792e9ca7472e81e3d3d69e9b65cb678465aac90b463ac02f2b490c0581c4e9aa8a33d2a5857decbe2c6d9ffb310f8e1f
+  languageName: node
+  linkType: hard
+
+"@open-draft/logger@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@open-draft/logger@npm:0.3.0"
+  dependencies:
+    is-node-process: "npm:^1.2.0"
+    outvariant: "npm:^1.4.0"
+  checksum: 10c0/90010647b22e9693c16258f4f9adb034824d1771d3baa313057b9a37797f571181005bc50415a934eaf7c891d90ff71dcd7a9d5048b0b6bb438f31bef2c7c5c1
+  languageName: node
+  linkType: hard
+
+"@open-draft/until@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "@open-draft/until@npm:2.1.0"
+  checksum: 10c0/61d3f99718dd86bb393fee2d7a785f961dcaf12f2055f0c693b27f4d0cd5f7a03d498a6d9289773b117590d794a43cd129366fd8e99222e4832f67b1653d54cf
   languageName: node
   linkType: hard
 
@@ -5744,6 +5850,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/set-cookie-parser@npm:^2.4.10":
+  version: 2.4.10
+  resolution: "@types/set-cookie-parser@npm:2.4.10"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/010b0c582ea70a2088618b4725808e80c30cce296c19ec58e51d94e0fd1038201b7b99238bf3ea74e1894163c8037d10a4f1729de62b2801ce240ff070f43e76
+  languageName: node
+  linkType: hard
+
+"@types/statuses@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@types/statuses@npm:2.0.6"
+  checksum: 10c0/dd88c220b0e2c6315686289525fd61472d2204d2e4bef4941acfb76bda01d3066f749ac74782aab5b537a45314fcd7d6261eefa40b6ec872691f5803adaa608d
+  languageName: node
+  linkType: hard
+
 "@types/unist@npm:*, @types/unist@npm:^3.0.0":
   version: 3.0.3
   resolution: "@types/unist@npm:3.0.3"
@@ -6224,6 +6346,7 @@ __metadata:
     jsdom: "npm:^26.1.0"
     jwt-decode: "npm:^4.0.0"
     lodash.debounce: "npm:^4.0.8"
+    msw: "npm:^2.14.2"
     qrcode.react: "npm:^3.1.0"
     quill: "npm:2.0.3"
     react: "npm:^18.2.0"
@@ -7248,6 +7371,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cli-width@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "cli-width@npm:4.1.0"
+  checksum: 10c0/1fbd56413578f6117abcaf858903ba1f4ad78370a4032f916745fa2c7e390183a9d9029cf837df320b0fdce8137668e522f60a30a5f3d6529ff3872d265a955f
+  languageName: node
+  linkType: hard
+
+"cliui@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "cliui@npm:8.0.1"
+  dependencies:
+    string-width: "npm:^4.2.0"
+    strip-ansi: "npm:^6.0.1"
+    wrap-ansi: "npm:^7.0.0"
+  checksum: 10c0/4bda0f09c340cbb6dfdc1ed508b3ca080f12992c18d68c6be4d9cf51756033d5266e61ec57529e610dacbf4da1c634423b0c1b11037709cc6b09045cbd815df5
+  languageName: node
+  linkType: hard
+
 "clone-deep@npm:^4.0.1":
   version: 4.0.1
   resolution: "clone-deep@npm:4.0.1"
@@ -7466,6 +7607,13 @@ __metadata:
   version: 0.5.0
   resolution: "cookie@npm:0.5.0"
   checksum: 10c0/c01ca3ef8d7b8187bae434434582288681273b5a9ed27521d4d7f9f7928fe0c920df0decd9f9d3bbd2d14ac432b8c8cf42b98b3bdd5bfe0e6edddeebebe8b61d
+  languageName: node
+  linkType: hard
+
+"cookie@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "cookie@npm:1.1.1"
+  checksum: 10c0/79c4ddc0fcad9c4f045f826f42edf54bcc921a29586a4558b0898277fa89fb47be95bc384c2253f493af7b29500c830da28341274527328f18eba9f58afa112c
   languageName: node
   linkType: hard
 
@@ -9010,6 +9158,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-string-truncated-width@npm:^3.0.2":
+  version: 3.0.3
+  resolution: "fast-string-truncated-width@npm:3.0.3"
+  checksum: 10c0/043b8663397d14a3880ce4f3407bcda60b40db9bbeafe62863a35d1f9c69ea17c8da3fcd72de235553e6c9cd053128cde9e24ca0d4a7463208f48db3cd23d981
+  languageName: node
+  linkType: hard
+
+"fast-string-width@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "fast-string-width@npm:3.0.2"
+  dependencies:
+    fast-string-truncated-width: "npm:^3.0.2"
+  checksum: 10c0/c8822d175315bb353ebe782b65214ac53b13e3bf704e03b132ea7bdfa8de6a636375b3ab7a4097545393d109381c37c4f387c72a462c90b61412dbc4632f39a7
+  languageName: node
+  linkType: hard
+
+"fast-wrap-ansi@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "fast-wrap-ansi@npm:0.2.0"
+  dependencies:
+    fast-string-width: "npm:^3.0.2"
+  checksum: 10c0/c0eb6debee565c5dbb9132dddff5c4d4aba5eb02185ae4dab285acd6186018cffca04264e92f373cbf592a9bcd1c33d65dba036030a8f3baeff1169969a1b59b
+  languageName: node
+  linkType: hard
+
 "fastest-stable-stringify@npm:^2.0.2":
   version: 2.0.2
   resolution: "fastest-stable-stringify@npm:2.0.2"
@@ -9418,6 +9591,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-caller-file@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "get-caller-file@npm:2.0.5"
+  checksum: 10c0/c6c7b60271931fa752aeb92f2b47e355eac1af3a2673f47c9589e8f8a41adc74d45551c1bc57b5e66a80609f10ffb72b6f575e4370d61cc3f7f3aaff01757cde
+  languageName: node
+  linkType: hard
+
 "get-func-name@npm:^2.0.1, get-func-name@npm:^2.0.2":
   version: 2.0.2
   resolution: "get-func-name@npm:2.0.2"
@@ -9650,6 +9830,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"graphql@npm:^16.13.2":
+  version: 16.13.2
+  resolution: "graphql@npm:16.13.2"
+  checksum: 10c0/64e822a0a0e4398781e4bc9765b88d370c08261498b517add4b878038ef7be2005b6b394a79a5102b9379d57052f60bc7f23fec8f39808d101984a74772ebd9d
+  languageName: node
+  linkType: hard
+
 "gunzip-maybe@npm:^1.4.2":
   version: 1.4.2
   resolution: "gunzip-maybe@npm:1.4.2"
@@ -9782,6 +9969,16 @@ __metadata:
   dependencies:
     "@types/hast": "npm:^3.0.0"
   checksum: 10c0/b898bc9fe27884b272580d15260b6bbdabe239973a147e97fa98c45fa0ffec967a481aaa42291ec34fb56530dc2d484d473d7e2bae79f39c83f3762307edfea8
+  languageName: node
+  linkType: hard
+
+"headers-polyfill@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "headers-polyfill@npm:5.0.1"
+  dependencies:
+    "@types/set-cookie-parser": "npm:^2.4.10"
+    set-cookie-parser: "npm:^3.0.1"
+  checksum: 10c0/c269730a88a12c88718037aa71f178601f2b193ba8a37e276b6ced6b8f7e06fc1ac051f2a7acb0a8b4cc878407066555fdcdbb270e90374baaa472cb26af0c30
   languageName: node
   linkType: hard
 
@@ -10317,6 +10514,13 @@ __metadata:
   version: 2.0.2
   resolution: "is-negative-zero@npm:2.0.2"
   checksum: 10c0/eda024c158f70f2017f3415e471b818d314da5ef5be68f801b16314d4a4b6304a74cbed778acf9e2f955bb9c1c5f2935c1be0c7c99e1ad12286f45366217b6a3
+  languageName: node
+  linkType: hard
+
+"is-node-process@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "is-node-process@npm:1.2.0"
+  checksum: 10c0/5b24fda6776d00e42431d7bcd86bce81cb0b6cabeb944142fe7b077a54ada2e155066ad06dbe790abdb397884bdc3151e04a9707b8cd185099efbc79780573ed
   languageName: node
   linkType: hard
 
@@ -11948,10 +12152,50 @@ __metadata:
   languageName: node
   linkType: hard
 
+"msw@npm:^2.14.2":
+  version: 2.14.2
+  resolution: "msw@npm:2.14.2"
+  dependencies:
+    "@inquirer/confirm": "npm:^6.0.11"
+    "@mswjs/interceptors": "npm:^0.41.3"
+    "@open-draft/deferred-promise": "npm:^3.0.0"
+    "@types/statuses": "npm:^2.0.6"
+    cookie: "npm:^1.1.1"
+    graphql: "npm:^16.13.2"
+    headers-polyfill: "npm:^5.0.1"
+    is-node-process: "npm:^1.2.0"
+    outvariant: "npm:^1.4.3"
+    path-to-regexp: "npm:^6.3.0"
+    picocolors: "npm:^1.1.1"
+    rettime: "npm:^0.11.7"
+    statuses: "npm:^2.0.2"
+    strict-event-emitter: "npm:^0.5.1"
+    tough-cookie: "npm:^6.0.1"
+    type-fest: "npm:^5.5.0"
+    until-async: "npm:^3.0.2"
+    yargs: "npm:^17.7.2"
+  peerDependencies:
+    typescript: ">= 4.8.x"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    msw: cli/index.js
+  checksum: 10c0/85dcf819047167b925fcb55b19a38533697e2ea27f341f637a21d311482478ee568d87ccf4a65c388fb7e90c238976b6ae06db3271f53dbc99add2cbc6719b44
+  languageName: node
+  linkType: hard
+
 "mutation-observer@npm:^1.0.3":
   version: 1.0.3
   resolution: "mutation-observer@npm:1.0.3"
   checksum: 10c0/2f010fdec4b860a6576558013bcaa691c4912e287ea1dc99ea3b9360b52586267b291e7a2a88c0f2a9b399b4ef1e116ce8c0f839f88d2d7c9b4323fb0badc321
+  languageName: node
+  linkType: hard
+
+"mute-stream@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "mute-stream@npm:3.0.0"
+  checksum: 10c0/12cdb36a101694c7a6b296632e6d93a30b74401873cf7507c88861441a090c71c77a58f213acadad03bc0c8fa186639dec99d68a14497773a8744320c136e701
   languageName: node
   linkType: hard
 
@@ -12365,6 +12609,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"outvariant@npm:^1.4.0, outvariant@npm:^1.4.3":
+  version: 1.4.3
+  resolution: "outvariant@npm:1.4.3"
+  checksum: 10c0/5976ca7740349cb8c71bd3382e2a762b1aeca6f33dc984d9d896acdf3c61f78c3afcf1bfe9cc633a7b3c4b295ec94d292048f83ea2b2594fae4496656eba992c
+  languageName: node
+  linkType: hard
+
 "p-limit@npm:^2.0.0, p-limit@npm:^2.2.0":
   version: 2.3.0
   resolution: "p-limit@npm:2.3.0"
@@ -12562,6 +12813,13 @@ __metadata:
   version: 0.1.7
   resolution: "path-to-regexp@npm:0.1.7"
   checksum: 10c0/50a1ddb1af41a9e68bd67ca8e331a705899d16fb720a1ea3a41e310480948387daf603abb14d7b0826c58f10146d49050a1291ba6a82b78a382d1c02c0b8f905
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:^6.3.0":
+  version: 6.3.0
+  resolution: "path-to-regexp@npm:6.3.0"
+  checksum: 10c0/73b67f4638b41cde56254e6354e46ae3a2ebc08279583f6af3d96fe4664fc75788f74ed0d18ca44fa4a98491b69434f9eee73b97bb5314bd1b5adb700f5c18d6
   languageName: node
   linkType: hard
 
@@ -14413,6 +14671,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"require-directory@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "require-directory@npm:2.1.1"
+  checksum: 10c0/83aa76a7bc1531f68d92c75a2ca2f54f1b01463cb566cf3fbc787d0de8be30c9dbc211d1d46be3497dac5785fe296f2dd11d531945ac29730643357978966e99
+  languageName: node
+  linkType: hard
+
 "require-from-string@npm:^2.0.2":
   version: 2.0.2
   resolution: "require-from-string@npm:2.0.2"
@@ -14488,6 +14753,13 @@ __metadata:
   version: 0.12.0
   resolution: "retry@npm:0.12.0"
   checksum: 10c0/59933e8501727ba13ad73ef4a04d5280b3717fd650408460c987392efe9d7be2040778ed8ebe933c5cbd63da3dcc37919c141ef8af0a54a6e4fca5a2af177bfe
+  languageName: node
+  linkType: hard
+
+"rettime@npm:^0.11.7":
+  version: 0.11.11
+  resolution: "rettime@npm:0.11.11"
+  checksum: 10c0/021fc9d9870ce04f032952e63fc5576f3f8e7c9c15513b1a479a64646df90239802eef6d60a98cbfb6ac87bb623d4f120a8ee71193d02984e3d2915c28695f6e
   languageName: node
   linkType: hard
 
@@ -14871,6 +15143,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"set-cookie-parser@npm:^3.0.1":
+  version: 3.1.0
+  resolution: "set-cookie-parser@npm:3.1.0"
+  checksum: 10c0/7465e389ff9fb7ff243fd55f0f48b5648d53a560903db170a7f766c2b82f22f4242c4d366fcdf12afdd376496f84058025d889e718459256ecbfc9a5fe7755f5
+  languageName: node
+  linkType: hard
+
 "set-function-length@npm:^1.1.1":
   version: 1.2.0
   resolution: "set-function-length@npm:1.2.0"
@@ -15202,6 +15481,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"statuses@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "statuses@npm:2.0.2"
+  checksum: 10c0/a9947d98ad60d01f6b26727570f3bcceb6c8fa789da64fe6889908fe2e294d57503b14bf2b5af7605c2d36647259e856635cd4c49eab41667658ec9d0080ec3f
+  languageName: node
+  linkType: hard
+
 "std-env@npm:^3.8.0":
   version: 3.10.0
   resolution: "std-env@npm:3.10.0"
@@ -15265,6 +15551,13 @@ __metadata:
   version: 1.0.3
   resolution: "stream-shift@npm:1.0.3"
   checksum: 10c0/939cd1051ca750d240a0625b106a2b988c45fb5a3be0cebe9a9858cb01bc1955e8c7b9fac17a9462976bea4a7b704e317c5c2200c70f0ca715a3363b9aa4fd3b
+  languageName: node
+  linkType: hard
+
+"strict-event-emitter@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "strict-event-emitter@npm:0.5.1"
+  checksum: 10c0/f5228a6e6b6393c57f52f62e673cfe3be3294b35d6f7842fc24b172ae0a6e6c209fa83241d0e433fc267c503bc2f4ffdbe41a9990ff8ffd5ac425ec0489417f7
   languageName: node
   linkType: hard
 
@@ -15625,6 +15918,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tagged-tag@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "tagged-tag@npm:1.0.0"
+  checksum: 10c0/91d25c9ffb86a91f20522cefb2cbec9b64caa1febe27ad0df52f08993ff60888022d771e868e6416cf2e72dab68449d2139e8709ba009b74c6c7ecd4000048d1
+  languageName: node
+  linkType: hard
+
 "tar-fs@npm:^2.1.1":
   version: 2.1.1
   resolution: "tar-fs@npm:2.1.1"
@@ -15821,6 +16121,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tldts-core@npm:^7.0.30":
+  version: 7.0.30
+  resolution: "tldts-core@npm:7.0.30"
+  checksum: 10c0/e3cd730e96b0e9c0332fcaab44d0257b668f9089644508e4f6f870d37bbf5c218243b7e83aa39690c87b386d1b0ad577772a5994969c4c81cc25a476f783ccd7
+  languageName: node
+  linkType: hard
+
 "tldts@npm:^6.1.32":
   version: 6.1.86
   resolution: "tldts@npm:6.1.86"
@@ -15829,6 +16136,17 @@ __metadata:
   bin:
     tldts: bin/cli.js
   checksum: 10c0/27ae7526d9d78cb97b2de3f4d102e0b4321d1ccff0648a7bb0e039ed54acbce86bacdcd9cd3c14310e519b457854e7bafbef1f529f58a1e217a737ced63f0940
+  languageName: node
+  linkType: hard
+
+"tldts@npm:^7.0.5":
+  version: 7.0.30
+  resolution: "tldts@npm:7.0.30"
+  dependencies:
+    tldts-core: "npm:^7.0.30"
+  bin:
+    tldts: bin/cli.js
+  checksum: 10c0/c36f7b480f09128303158e4738a82426c33e8da9f77d4fb57a2d5ef5896c803d7a3c1d53ade965712f9cb4946935139b6d192a18698665556ca504493c7c265e
   languageName: node
   linkType: hard
 
@@ -15882,6 +16200,15 @@ __metadata:
   dependencies:
     tldts: "npm:^6.1.32"
   checksum: 10c0/5f95023a47de0f30a902bba951664b359725597d8adeabc66a0b93a931c3af801e1e697dae4b8c21a012056c0ea88bd2bf4dfe66b2adcf8e2f42cd9796fe0626
+  languageName: node
+  linkType: hard
+
+"tough-cookie@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "tough-cookie@npm:6.0.1"
+  dependencies:
+    tldts: "npm:^7.0.5"
+  checksum: 10c0/ec70bd6b1215efe4ed31a158f0be3e4c9088fcbd8620edc23a5860d4f3d85c757b77e274baaa700f7b25e409f4181552ed189603c2b2e1a9f88104da3a61a37d
   languageName: node
   linkType: hard
 
@@ -16090,6 +16417,15 @@ __metadata:
   version: 2.19.0
   resolution: "type-fest@npm:2.19.0"
   checksum: 10c0/a5a7ecf2e654251613218c215c7493574594951c08e52ab9881c9df6a6da0aeca7528c213c622bc374b4e0cb5c443aa3ab758da4e3c959783ce884c3194e12cb
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^5.5.0":
+  version: 5.6.0
+  resolution: "type-fest@npm:5.6.0"
+  dependencies:
+    tagged-tag: "npm:^1.0.0"
+  checksum: 10c0/5468a8ffda7f3904e6f7bbd8069eb8b6dd4bd9156e206df7a01d09a73e28cd1afedf74ead9d0fc12841c8c90074194859feca240511c50800962fde1bd9ddcbc
   languageName: node
   linkType: hard
 
@@ -16404,6 +16740,13 @@ __metadata:
     webpack-sources: "npm:^3.2.3"
     webpack-virtual-modules: "npm:^0.6.1"
   checksum: 10c0/3a1de3b1b76f0457aea6c18671573b0607414dfc65b581bc9af7908273513ad087ac838fd4e9021897ad0d515243ae9b784e0c6224d30e4c213dec998a53c7c7
+  languageName: node
+  linkType: hard
+
+"until-async@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "until-async@npm:3.0.2"
+  checksum: 10c0/61c8b03895dbe18fe3d90316d0a1894e0c131ea4b1673f6ce78eed993d0bb81bbf4b7adf8477e9ff7725782a76767eed9d077561cfc9f89b4a1ebe61f7c9828e
   languageName: node
   linkType: hard
 
@@ -16966,7 +17309,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0, wrap-ansi@npm:^7.0.0":
   version: 7.0.0
   resolution: "wrap-ansi@npm:7.0.0"
   dependencies:
@@ -17076,6 +17419,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"y18n@npm:^5.0.5":
+  version: 5.0.8
+  resolution: "y18n@npm:5.0.8"
+  checksum: 10c0/4df2842c36e468590c3691c894bc9cdbac41f520566e76e24f59401ba7d8b4811eb1e34524d57e54bc6d864bcb66baab7ffd9ca42bf1eda596618f9162b91249
+  languageName: node
+  linkType: hard
+
 "yallist@npm:^3.0.2":
   version: 3.1.1
   resolution: "yallist@npm:3.1.1"
@@ -17094,6 +17444,28 @@ __metadata:
   version: 1.10.2
   resolution: "yaml@npm:1.10.2"
   checksum: 10c0/5c28b9eb7adc46544f28d9a8d20c5b3cb1215a886609a2fd41f51628d8aaa5878ccd628b755dbcd29f6bb4921bd04ffbc6dcc370689bb96e594e2f9813d2605f
+  languageName: node
+  linkType: hard
+
+"yargs-parser@npm:^21.1.1":
+  version: 21.1.1
+  resolution: "yargs-parser@npm:21.1.1"
+  checksum: 10c0/f84b5e48169479d2f402239c59f084cfd1c3acc197a05c59b98bab067452e6b3ea46d4dd8ba2985ba7b3d32a343d77df0debd6b343e5dae3da2aab2cdf5886b2
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^17.7.2":
+  version: 17.7.2
+  resolution: "yargs@npm:17.7.2"
+  dependencies:
+    cliui: "npm:^8.0.1"
+    escalade: "npm:^3.1.1"
+    get-caller-file: "npm:^2.0.5"
+    require-directory: "npm:^2.1.1"
+    string-width: "npm:^4.2.3"
+    y18n: "npm:^5.0.5"
+    yargs-parser: "npm:^21.1.1"
+  checksum: 10c0/ccd7e723e61ad5965fffbb791366db689572b80cca80e0f96aad968dfff4156cd7cd1ad18607afe1046d8241e6fb2d6c08bf7fa7bfb5eaec818735d8feac8f05
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3052,6 +3052,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@playwright/test@npm:^1.54.1":
+  version: 1.59.1
+  resolution: "@playwright/test@npm:1.59.1"
+  dependencies:
+    playwright: "npm:1.59.1"
+  bin:
+    playwright: cli.js
+  checksum: 10c0/8c2d94a860d3c254a0b114df2f888ad0a0e9310f45b6059bd5d4da196d965cadf6922267cef0881cfa9784d4bef6d78363d2c2d94caa64be67ff644c41162137
+  languageName: node
+  linkType: hard
+
 "@radix-ui/number@npm:1.0.1":
   version: 1.0.1
   resolution: "@radix-ui/number@npm:1.0.1"
@@ -6195,6 +6206,7 @@ __metadata:
     "@emotion/babel-plugin": "npm:^11.11.0"
     "@emotion/react": "npm:^11.11.3"
     "@emotion/styled": "npm:^11.11.0"
+    "@playwright/test": "npm:^1.54.1"
     "@react-pdf/renderer": "npm:^3.4.4"
     "@tanstack/react-table": "npm:^8.12.0"
     "@testing-library/dom": "npm:^10.4.0"
@@ -9318,12 +9330,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@npm:2.3.2":
+  version: 2.3.2
+  resolution: "fsevents@npm:2.3.2"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/be78a3efa3e181cda3cf7a4637cb527bcebb0bd0ea0440105a3bb45b86f9245b307dc10a2507e8f4498a7d4ec349d1910f4d73e4d4495b16103106e07eee735b
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "fsevents@npm:^2.3.2, fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>":
+  version: 2.3.2
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
+  dependencies:
+    node-gyp: "npm:latest"
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -12661,6 +12692,30 @@ __metadata:
   dependencies:
     find-up: "npm:^5.0.0"
   checksum: 10c0/793a496d685dc55bbbdbbb22d884535c3b29241e48e3e8d37e448113a71b9e42f5481a61fdc672d7322de12fbb2c584dd3a68bf89b18fffce5c48a390f911bc5
+  languageName: node
+  linkType: hard
+
+"playwright-core@npm:1.59.1":
+  version: 1.59.1
+  resolution: "playwright-core@npm:1.59.1"
+  bin:
+    playwright-core: cli.js
+  checksum: 10c0/d41a74d9681ce3beb3d5239e9ed577710b4ad099a6ca2476219c6599d51e9cb4b80bd72ed82c528da6a5d929c18ae3b872cf02bb83f78fa1c2cb9199c501abee
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.59.1":
+  version: 1.59.1
+  resolution: "playwright@npm:1.59.1"
+  dependencies:
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.59.1"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 10c0/dfe38396e616e5c4f98825ce90037bb96e477c5a2bd9258a24854f8ce72a8a41427b19098863866f85aa0216e70287dd537c4438d761aca93995e31ae099c533
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 배경
- 기존 테스트 커버리지를 유틸/통합 중심에서 사용자 플로우 중심까지 확장하기 위해 E2E를 도입했습니다.
- 시각 스냅샷 회귀 대신 기능 검증 중심 테스트로 방향을 정리했습니다.
- 라우팅 케이스는 E2E 과설계 구간이 있어 통합 테스트로 이관해 유지보수 비용을 낮췄습니다.

## 변경 사항
### 1) Playwright 기능 E2E 도입
- 추가
  - `apps/admin/e2e/functional/auth-routing.e2e.spec.ts`
  - `apps/admin/e2e/functional/prequestion-response-flow.e2e.spec.ts`
  - `apps/admin/e2e/functional/settlement-request-flow.e2e.spec.ts`
  - `apps/admin/playwright.config.ts`
- 스크립트 추가/정리
  - `test:e2e`
  - `test:e2e:functional`
  - `test:e2e:ui`

### 2) MSW 기반 E2E mock 환경 구축
- 추가
  - `apps/admin/public/mockServiceWorker.js`
  - `apps/admin/src/mocks/handlers.ts`
  - `apps/admin/src/mocks/browser.ts`
  - `apps/admin/e2e/helpers/msw.ts`
- 수정
  - `apps/admin/src/main.tsx`
  - `apps/admin/src/vite-env.d.ts`
  - `apps/admin/vite.config.ts`

### 3) 통합 테스트 추가
- 추가
  - `apps/admin/src/pages/HomePage/HomePage.integration.test.tsx`
  - `apps/admin/src/pages/Landing/Landing.integration.test.tsx`
  - `apps/admin/src/components/ShowPreQuestion/ResponseTab/ResponseTab.integration.test.tsx`
  - `apps/admin/src/App.auth-routing.integration.test.tsx`
 
### 4) 라우팅 테스트 구조 최적화
- `PrivateRoute` 를 분리해 테스트 가능성 향상
  - 추가: `apps/admin/src/routes/PrivateRoute.tsx`
  - 수정: `apps/admin/src/App.tsx`
- `auth-routing` E2E는 스모크 1개만 유지
- 로그인/webview 분기는 통합 테스트로 이관

## 검증
`yarn workspace admin type-check` 통과
`yarn workspace admin test App.auth-routing.integration.test.tsx` 통과
`yarn workspace admin test:e2e:functional` 통과
`yarn workspace admin test:e2e:functional --grep "Auth routing guard"` 통과

## 참고
의존성/환경 반영으로 아래 파일도 함께 변경되었습니다.
- `.pnp.cjs`
- `yarn.lock`
- `apps/admin/.gitignore`