### PR TITLE
preview 최적화 1차

### DIFF
--- a/apps/preview/index.html
+++ b/apps/preview/index.html
@@ -4,6 +4,21 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="shortcut icon" href="https://preview.boolti.in/favicon.png" />
+    <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin />
+    <link
+      rel="preload"
+      href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.9/static/pretendard-dynamic-subset.min.css"
+      as="style"
+      crossorigin
+      onload="this.onload=null;this.rel='stylesheet'"
+    />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.9/static/pretendard-dynamic-subset.min.css"
+        crossorigin
+      />
+    </noscript>
 
     <title>핫한 공연 예매의 시작, 불티</title>
     <link rel="canonical" href="https://boolti.in" />

--- a/apps/preview/src/App.tsx
+++ b/apps/preview/src/App.tsx
@@ -11,6 +11,31 @@ import { fetcher } from '@boolti/api/src/fetcher';
 import NotFound from './components/NotFound';
 import ShowInfoDetailPage from './pages/ShowInfoDetailPage';
 
+const SHOW_IMAGE_PRELOAD_ID = 'show-preview-lcp-image-preload';
+
+const preloadShowImage = (imageUrl?: string) => {
+  if (!imageUrl || typeof document === 'undefined') {
+    return;
+  }
+
+  const existingPreload = document.getElementById(SHOW_IMAGE_PRELOAD_ID) as HTMLLinkElement | null;
+
+  if (existingPreload?.href === imageUrl) {
+    return;
+  }
+
+  existingPreload?.remove();
+
+  const preload = document.createElement('link');
+  preload.id = SHOW_IMAGE_PRELOAD_ID;
+  preload.rel = 'preload';
+  preload.as = 'image';
+  preload.href = imageUrl;
+  preload.setAttribute('fetchpriority', 'high');
+
+  document.head.appendChild(preload);
+};
+
 const showPageLoader = async ({ params }: { params: { showId?: string } }) => {
   const showId = params.showId;
   if (showId) {
@@ -18,6 +43,7 @@ const showPageLoader = async ({ params }: { params: { showId?: string } }) => {
       fetcher.get<ShowPreviewResponse>(`web/papi/v1/shows/${showId}`),
       fetcher.get<ShowCastTeamReadResponse[]>(`web/papi/v1/shows/${showId}/cast-teams`),
     ]);
+    preloadShowImage(response[0].showImg[0]?.path);
     return response;
   }
 };

--- a/apps/preview/src/App.tsx
+++ b/apps/preview/src/App.tsx
@@ -5,7 +5,6 @@ import { ShowCastTeamReadResponse, ShowPreviewResponse } from '@boolti/api';
 import { BooltiUIProvider } from '@boolti/ui';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { HelmetProvider } from 'react-helmet-async';
-import { NavermapsProvider } from 'react-naver-maps';
 import ShowPreviewPage from './pages/ShowPreviewPage';
 import { fetcher } from '@boolti/api/src/fetcher';
 import NotFound from './components/NotFound';
@@ -78,17 +77,13 @@ const router = createBrowserRouter([
   },
 ]);
 
-const X_NCP_APIGW_API_KEY_ID = import.meta.env.VITE_X_NCP_APIGW_API_KEY_ID;
-
 const App = () => {
   return (
-    <NavermapsProvider ncpKeyId={X_NCP_APIGW_API_KEY_ID}>
-      <BooltiUIProvider>
-        <HelmetProvider>
-          <RouterProvider router={router} />
-        </HelmetProvider>
-      </BooltiUIProvider>
-    </NavermapsProvider>
+    <BooltiUIProvider>
+      <HelmetProvider>
+        <RouterProvider router={router} />
+      </HelmetProvider>
+    </BooltiUIProvider>
   );
 };
 

--- a/apps/preview/src/constants/ncp.ts
+++ b/apps/preview/src/constants/ncp.ts
@@ -1,0 +1,1 @@
+export const X_NCP_APIGW_API_KEY_ID = import.meta.env.VITE_X_NCP_APIGW_API_KEY_ID;

--- a/apps/preview/src/index.css
+++ b/apps/preview/src/index.css
@@ -1,5 +1,3 @@
-@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.9/static/pretendard-dynamic-subset.min.css');
-
 * {
   font-family:
     'Pretendard Variable',

--- a/apps/preview/src/pages/ShowInfoDetailPage/index.tsx
+++ b/apps/preview/src/pages/ShowInfoDetailPage/index.tsx
@@ -3,6 +3,7 @@ import { ShowInfoDetail } from '@boolti/ui';
 import { format } from 'date-fns';
 import { useLoaderData } from 'react-router-dom';
 import Styled from './ShowInfoDetailPage.styles';
+import { X_NCP_APIGW_API_KEY_ID } from '../../constants/ncp';
 
 const ShowInfoDetailPage: React.FC = () => {
   const [show, { count: soldTicketCount }] = useLoaderData() as [
@@ -52,6 +53,7 @@ const ShowInfoDetailPage: React.FC = () => {
         onClickMessageLink={messageLinkClickHandler}
         onClickCallLinkMobile={callLinkClickHandler}
         onClickMessageLinkMobile={messageLinkClickHandler}
+        naverMapClientId={X_NCP_APIGW_API_KEY_ID}
       />
     </Styled.Container>
   );

--- a/apps/preview/src/pages/ShowPreviewPage/index.tsx
+++ b/apps/preview/src/pages/ShowPreviewPage/index.tsx
@@ -2,18 +2,23 @@ import { ShowCastTeamReadResponse, ShowPreviewResponse } from '@boolti/api';
 import { Footer, ShowPreview, useDeviceByWidth, useDialog } from '@boolti/ui';
 import { format, setDefaultOptions } from 'date-fns';
 import { ko } from 'date-fns/locale';
-import { QRCodeSVG } from 'qrcode.react';
+import { lazy, Suspense, useState } from 'react';
 import { useLoaderData } from 'react-router-dom';
 
 import Styled from './ShowPreviewPage.styles';
 import { Meta } from '../../components/Meta';
 import BooltiGrayLogo from '../../components/BooltiGrayLogo';
 import useBodyScrollLock from '../../hooks/useBodyScrollLock';
-import { useState } from 'react';
 import { EXTERNAL_URL, openStoreLink } from '../../constants/external';
 import { navigateToAppScheme } from '../../utils/app';
 
 setDefaultOptions({ locale: ko });
+
+const QRCodeSVG = lazy(() =>
+  import('qrcode.react').then((module) => ({
+    default: module.QRCodeSVG,
+  })),
+);
 
 const getAppScheme = (showId: number) => {
   return `boolti://show/${showId}`;
@@ -150,7 +155,9 @@ const ShowPreviewPage = () => {
         <Styled.DialogContainer>
           <Styled.DialogQRCodeContainer>
             <Styled.QRCodeContainer>
-              <QRCodeSVG value={getPreviewLink(id)} size={182} level="H" />
+              <Suspense fallback={null}>
+                <QRCodeSVG value={getPreviewLink(id)} size={182} level="H" />
+              </Suspense>
             </Styled.QRCodeContainer>
             <BooltiGrayLogo />
           </Styled.DialogQRCodeContainer>

--- a/apps/preview/src/pages/ShowPreviewPage/index.tsx
+++ b/apps/preview/src/pages/ShowPreviewPage/index.tsx
@@ -223,6 +223,7 @@ const ShowPreviewPage = () => {
             onShareShowPreviewLink={shareShowPreviewLink}
             onShareShowInfo={shareShowInfo}
             onCloseShareDropdown={shareDropdownCloseHandler}
+            prioritizeFirstImage
           />
           <Styled.FooterWrapper>
             <Footer darkMode />

--- a/apps/preview/src/pages/ShowPreviewPage/index.tsx
+++ b/apps/preview/src/pages/ShowPreviewPage/index.tsx
@@ -10,6 +10,7 @@ import { Meta } from '../../components/Meta';
 import BooltiGrayLogo from '../../components/BooltiGrayLogo';
 import useBodyScrollLock from '../../hooks/useBodyScrollLock';
 import { EXTERNAL_URL, openStoreLink } from '../../constants/external';
+import { X_NCP_APIGW_API_KEY_ID } from '../../constants/ncp';
 import { navigateToAppScheme } from '../../utils/app';
 
 setDefaultOptions({ locale: ko });
@@ -231,6 +232,7 @@ const ShowPreviewPage = () => {
             onShareShowInfo={shareShowInfo}
             onCloseShareDropdown={shareDropdownCloseHandler}
             prioritizeFirstImage
+            naverMapClientId={X_NCP_APIGW_API_KEY_ID}
           />
           <Styled.FooterWrapper>
             <Footer darkMode />

--- a/apps/preview/src/pages/ShowPreviewPage/index.tsx
+++ b/apps/preview/src/pages/ShowPreviewPage/index.tsx
@@ -195,7 +195,10 @@ const ShowPreviewPage = () => {
         <Styled.ShowPreviewContainer>
           <ShowPreview
             show={{
-              images: showImg.map((file) => file.path),
+              images: showImg.map((file) => ({
+                src: file.path,
+                thumbnailSrc: file.thumbnailPath,
+              })),
               name: title,
               date: format(new Date(date), 'yyyy.MM.dd (E)'),
               startTime: format(new Date(date), 'HH:mm'),

--- a/packages/ui/src/components/PreviewMap/PreviewMapWithProvider.tsx
+++ b/packages/ui/src/components/PreviewMap/PreviewMapWithProvider.tsx
@@ -1,0 +1,21 @@
+import { NavermapsProvider } from 'react-naver-maps';
+
+import PreviewMap from './index';
+
+interface Props {
+  latitude: number;
+  longitude: number;
+  name: string;
+  isAppWebview: boolean;
+  ncpKeyId: string;
+}
+
+const PreviewMapWithProvider = ({ ncpKeyId, ...previewMapProps }: Props) => {
+  return (
+    <NavermapsProvider ncpKeyId={ncpKeyId}>
+      <PreviewMap {...previewMapProps} />
+    </NavermapsProvider>
+  );
+};
+
+export default PreviewMapWithProvider;

--- a/packages/ui/src/components/ShowPreview/ShowInfoDetail.tsx
+++ b/packages/ui/src/components/ShowPreview/ShowInfoDetail.tsx
@@ -7,6 +7,7 @@ import Styled from './ShowPreview.styles';
 import ShowNoticeHtmlContent from './ShowNoticeHtmlContent';
 
 const PreviewMap = lazy(() => import('../PreviewMap'));
+const PreviewMapWithProvider = lazy(() => import('../PreviewMap/PreviewMapWithProvider'));
 
 interface Props {
   show: {
@@ -28,6 +29,7 @@ interface Props {
   onClickCallLinkMobile?: () => void;
   onClickMessageLinkMobile?: () => void;
   onClickViewNotice?: () => void;
+  naverMapClientId?: string;
 }
 
 const ShowInfoDetail = ({
@@ -50,6 +52,7 @@ const ShowInfoDetail = ({
   onClickCallLinkMobile,
   onClickMessageLinkMobile,
   onClickViewNotice,
+  naverMapClientId,
 }: Props) => {
   const showNoticeRef = useRef<HTMLDivElement>(null);
   const swiper = useSwiper();
@@ -147,12 +150,22 @@ const ShowInfoDetail = ({
         </Styled.ShowInfoDescription>
         {latitude && longitude && (
           <Suspense fallback={null}>
-            <PreviewMap
-              latitude={latitude}
-              longitude={longitude}
-              name={placeName}
-              isAppWebview={isAppWebview}
-            />
+            {naverMapClientId ? (
+              <PreviewMapWithProvider
+                latitude={latitude}
+                longitude={longitude}
+                name={placeName}
+                isAppWebview={isAppWebview}
+                ncpKeyId={naverMapClientId}
+              />
+            ) : (
+              <PreviewMap
+                latitude={latitude}
+                longitude={longitude}
+                name={placeName}
+                isAppWebview={isAppWebview}
+              />
+            )}
           </Suspense>
         )}
       </Styled.ShowInfoGroup>

--- a/packages/ui/src/components/ShowPreview/ShowInfoDetail.tsx
+++ b/packages/ui/src/components/ShowPreview/ShowInfoDetail.tsx
@@ -1,11 +1,12 @@
-import { useRef, useState, useEffect } from 'react';
+import { lazy, Suspense, useRef, useState, useEffect } from 'react';
 import { useSwiper } from 'swiper/react';
 import { showToast, checkIsWebView, TOAST_DURATIONS } from '@boolti/bridge';
 import { CallIcon, ChevronDownIcon, ChevronUpIcon, MessageIcon, TicketIcon } from '@boolti/icon';
 
 import Styled from './ShowPreview.styles';
-import PreviewMap from '../PreviewMap';
 import ShowNoticeHtmlContent from './ShowNoticeHtmlContent';
+
+const PreviewMap = lazy(() => import('../PreviewMap'));
 
 interface Props {
   show: {
@@ -145,12 +146,14 @@ const ShowInfoDetail = ({
           </Styled.ShowInfoDescriptionText>
         </Styled.ShowInfoDescription>
         {latitude && longitude && (
-          <PreviewMap
-            latitude={latitude}
-            longitude={longitude}
-            name={placeName}
-            isAppWebview={isAppWebview}
-          />
+          <Suspense fallback={null}>
+            <PreviewMap
+              latitude={latitude}
+              longitude={longitude}
+              name={placeName}
+              isAppWebview={isAppWebview}
+            />
+          </Suspense>
         )}
       </Styled.ShowInfoGroup>
       <Styled.ShowInfoGroup>

--- a/packages/ui/src/components/ShowPreview/ShowPreview.styles.ts
+++ b/packages/ui/src/components/ShowPreview/ShowPreview.styles.ts
@@ -1,9 +1,14 @@
 import styled from '@emotion/styled';
+import type { ImgHTMLAttributes } from 'react';
 import { mq_lg } from '../../systems';
 
 interface ShowInfoDescriptionProps {
   collapse?: boolean;
   isOverflow?: boolean;
+}
+
+interface ShowImageProps extends ImgHTMLAttributes<HTMLImageElement> {
+  fetchpriority?: 'high' | 'low' | 'auto';
 }
 
 const ShowPreview = styled.div`
@@ -98,7 +103,7 @@ const ShareDropdownItem = styled.button`
   cursor: pointer;
 `;
 
-const ShowImage = styled.img`
+const ShowImage = styled.img<ShowImageProps>`
   width: 100%;
   height: auto;
   aspect-ratio: 299 / 419;

--- a/packages/ui/src/components/ShowPreview/index.tsx
+++ b/packages/ui/src/components/ShowPreview/index.tsx
@@ -55,6 +55,7 @@ interface ShowPreviewProps {
   onShareShowInfo?: () => void;
   onCloseShareDropdown?: () => void;
   prioritizeFirstImage?: boolean;
+  naverMapClientId?: string;
 }
 
 const ShowPreview = ({
@@ -71,6 +72,7 @@ const ShowPreview = ({
   onShareShowInfo,
   onCloseShareDropdown,
   prioritizeFirstImage = false,
+  naverMapClientId,
 }: ShowPreviewProps) => {
   const { images, name, date, startTime, runningTime, placeName } = show;
 
@@ -203,6 +205,7 @@ const ShowPreview = ({
                   onClickMessageLink={onClickLink}
                   onClickCallLinkMobile={onClickLinkMobile}
                   onClickMessageLinkMobile={onClickLinkMobile}
+                  naverMapClientId={naverMapClientId}
                 />
               ),
             },

--- a/packages/ui/src/components/ShowPreview/index.tsx
+++ b/packages/ui/src/components/ShowPreview/index.tsx
@@ -17,9 +17,16 @@ interface ShowImageLoadingProps extends ImgHTMLAttributes<HTMLImageElement> {
   fetchpriority?: 'high' | 'low' | 'auto';
 }
 
+type ShowPreviewImage =
+  | string
+  | {
+      src: string;
+      thumbnailSrc?: string;
+    };
+
 interface ShowPreviewProps {
   show: {
-    images: string[];
+    images: ShowPreviewImage[];
     name: string;
     date: string;
     startTime: string;
@@ -159,6 +166,8 @@ const ShowPreview = ({
           modules={[Pagination]}
         >
           {images.map((image, index) => {
+            const imageSrc = typeof image === 'string' ? image : image.src;
+            const imageThumbnailSrc = typeof image === 'string' ? undefined : image.thumbnailSrc;
             const imageLoadingProps: ShowImageLoadingProps = prioritizeFirstImage
               ? {
                   fetchpriority: index === 0 ? 'high' : 'auto',
@@ -167,9 +176,15 @@ const ShowPreview = ({
               : {};
 
             return (
-              <SwiperSlide key={image}>
+              <SwiperSlide key={imageSrc}>
                 <Styled.ShowImage
-                  src={image}
+                  src={imageSrc}
+                  srcSet={
+                    imageThumbnailSrc && imageThumbnailSrc !== imageSrc
+                      ? `${imageThumbnailSrc} 480w, ${imageSrc} 800w`
+                      : undefined
+                  }
+                  sizes="(max-width: 640px) calc(100vw - 76px), 564px"
                   alt={name}
                   decoding="async"
                   {...imageLoadingProps}

--- a/packages/ui/src/components/ShowPreview/index.tsx
+++ b/packages/ui/src/components/ShowPreview/index.tsx
@@ -1,6 +1,7 @@
 import 'swiper/css';
 import 'swiper/css/pagination';
 
+import type { ImgHTMLAttributes } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { Pagination } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
@@ -11,6 +12,10 @@ import Tab from '../Tab';
 import ShowCastInfo from './ShowCastInfo';
 import ShowInfoDetail from './ShowInfoDetail';
 import ShowPreviewNotice from './ShowPreviewNotice';
+
+interface ShowImageLoadingProps extends ImgHTMLAttributes<HTMLImageElement> {
+  fetchpriority?: 'high' | 'low' | 'auto';
+}
 
 interface ShowPreviewProps {
   show: {
@@ -49,6 +54,7 @@ interface ShowPreviewProps {
   onShareShowPreviewLink?: () => void;
   onShareShowInfo?: () => void;
   onCloseShareDropdown?: () => void;
+  prioritizeFirstImage?: boolean;
 }
 
 const ShowPreview = ({
@@ -64,6 +70,7 @@ const ShowPreview = ({
   onShareShowPreviewLink,
   onShareShowInfo,
   onCloseShareDropdown,
+  prioritizeFirstImage = false,
 }: ShowPreviewProps) => {
   const { images, name, date, startTime, runningTime, placeName } = show;
 
@@ -149,11 +156,25 @@ const ShowPreview = ({
           }}
           modules={[Pagination]}
         >
-          {images.map((image) => (
-            <SwiperSlide key={image}>
-              <Styled.ShowImage src={image} alt={name} />
-            </SwiperSlide>
-          ))}
+          {images.map((image, index) => {
+            const imageLoadingProps: ShowImageLoadingProps = prioritizeFirstImage
+              ? {
+                  fetchpriority: index === 0 ? 'high' : 'auto',
+                  loading: index === 0 ? 'eager' : 'lazy',
+                }
+              : {};
+
+            return (
+              <SwiperSlide key={image}>
+                <Styled.ShowImage
+                  src={image}
+                  alt={name}
+                  decoding="async"
+                  {...imageLoadingProps}
+                />
+              </SwiperSlide>
+            );
+          })}
         </Swiper>
         <Styled.ShowName>{name}</Styled.ShowName>
         <Styled.ShowHeaderInfoList>


### PR DESCRIPTION
## 작업 내용

preview 앱의 `/show/:showId` 공연 상세 페이지 Lighthouse 결과를 기준으로 초기 로딩 성능을 개선했습니다.

### LCP 포스터 이미지 로딩 개선

- 공연 상세 loader에서 첫 포스터 이미지 URL을 받은 직후 `<link rel="preload" as="image">`를 주입합니다.
- `ShowPreview`에 `prioritizeFirstImage` 옵션을 추가해 preview 실제 페이지에서만 첫 이미지에 `fetchpriority="high"`, `loading="eager"`를 적용합니다.
- 나머지 캐러셀 이미지는 `loading="lazy"`로 늦게 로드합니다.
- React 현재 버전에서 `fetchPriority` camelCase가 DOM attribute로 정상 처리되지 않아 lowercase `fetchpriority`를 사용했습니다.

### 포스터 이미지 후보 제공

- `ShowPreview`의 `images` 타입을 기존 `string[]`과 `{ src, thumbnailSrc }[]`를 모두 받을 수 있도록 확장했습니다.
- preview 페이지에서는 API의 `showImg.path`와 `showImg.thumbnailPath`를 함께 전달합니다.
- `srcSet`/`sizes`를 추가해 브라우저가 화면 조건에 맞는 이미지 후보를 선택할 수 있게 했습니다.
- 기존 admin 미리보기처럼 `string[]`을 넘기는 사용처는 그대로 동작합니다.

### 폰트 로딩 개선

- `apps/preview/src/index.css`의 Pretendard 외부 `@import`를 제거했습니다.
- `apps/preview/index.html`에서 `cdnjs.cloudflare.com` preconnect와 stylesheet preload를 사용하도록 변경했습니다.
- JS 비활성 환경을 위해 `noscript` fallback을 추가했습니다.

### 지도/QR 등 부가 기능 지연 로딩

- QR 코드는 예매 다이얼로그가 열릴 때 lazy-load합니다.
- `PreviewMap`은 지도 영역 렌더링 시점에 lazy-load합니다.
- preview 앱 루트의 `NavermapsProvider`를 제거하고, 지도 영역에서만 provider를 로드하도록 분리했습니다.
- Naver Maps client id는 `apps/preview/src/constants/ncp.ts`로 모았습니다.

## 변경 영향

- `ShowPreview`는 `packages/ui` 공유 컴포넌트라 기존 사용처를 확인했습니다.
- `apps/admin`의 공연 미리보기는 기존처럼 `string[]` 이미지를 넘기며, `prioritizeFirstImage`를 사용하지 않으므로 이미지 우선 로딩 정책이 자동 적용되지 않습니다.
- `apps/admin`은 기존 top-level `NavermapsProvider` 구조를 유지합니다.
- preview 앱만 지도 provider를 lazy boundary 안으로 옮겼습니다.

## 검증

- `yarn workspace preview type-check`
- `yarn workspace preview build`
- `yarn workspace @boolti/ui type-check`
- `yarn workspace admin type-check`

## 빌드 결과 참고

지도 provider 분리 후 preview production build 기준 메인 청크가 약 `511.60kB`에서 `482.79kB`로 감소했고, Vite의 500kB chunk warning이 사라졌습니다.

## 남은 과제

- `file.boolti.in`의 공식 이미지 변환 규칙이 확인되면 WebP/AVIF 및 width 기반 이미지 URL을 적용할 수 있습니다.
- 현재는 `thumbnailPath`를 `srcSet` 후보로 활용하는 수준입니다.
- `/show/:showId`를 SSR/prerender하면 초기 HTML에 첫 포스터 preload와 show별 메타를 포함할 수 있어 LCP request discovery를 더 강하게 개선할 수 있습니다.
- lazy-load로 인해 지도/QR 최초 사용 시점은 개발환경에서 이전보다 늦게 느껴질 수 있습니다.
