### PR TITLE
fix(place): 지도 크래시 수정 및 404·에러 페이지 추가

### DIFF
--- a/apps/place/src/App.tsx
+++ b/apps/place/src/App.tsx
@@ -8,6 +8,7 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 
 import ConcertHallPage from './pages/ConcertHallPage';
 import ErrorPage from './pages/ErrorPage';
+import NotFoundPage from './pages/NotFoundPage';
 
 const router = createBrowserRouter([
   {
@@ -17,7 +18,7 @@ const router = createBrowserRouter([
   },
   {
     path: '*',
-    element: <ErrorPage />,
+    element: <NotFoundPage />,
   },
 ]);
 

--- a/apps/place/src/components/Error/index.tsx
+++ b/apps/place/src/components/Error/index.tsx
@@ -1,0 +1,34 @@
+import styled from '@emotion/styled';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  height: 290px;
+  width: 100%;
+`;
+
+const Title = styled.span`
+  font-family: 'SB Aggro';
+  font-size: 20px;
+  line-height: 30px;
+  letter-spacing: -0.6px;
+  color: ${({ theme }) => theme.palette.mobile.grey.g20};
+`;
+
+const Description = styled.span`
+  font-size: 16px;
+  line-height: 24px;
+  color: ${({ theme }) => theme.palette.mobile.grey.g30};
+`;
+
+const Error = () => (
+  <Container>
+    <Title>ERROR</Title>
+    <Description>잠시 후 다시 시도해 주세요.</Description>
+  </Container>
+);
+
+export default Error;

--- a/apps/place/src/components/HomeTab/index.tsx
+++ b/apps/place/src/components/HomeTab/index.tsx
@@ -2,7 +2,7 @@ import type { ConcertHallProfileResponse } from '@boolti/api';
 import { checkIsWebView } from '@boolti/bridge';
 import { ChevronDownIcon, ChevronUpIcon } from '@boolti/icon';
 import { PreviewMapWithProvider, useToast } from '@boolti/ui';
-import { useLayoutEffect, useRef, useState } from 'react';
+import { useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import GalleryModal, { type GalleryMode } from '~/components/GalleryModal';
 import {
@@ -86,6 +86,25 @@ const HomeTab = ({ profile }: Props) => {
   const hasMap =
     location?.latitude != null && location?.longitude != null && Boolean(X_NCP_APIGW_API_KEY_ID);
 
+  // 갤러리 모달 open/close 등 HomeTab 리렌더 때 지도까지 리렌더되면
+  // react-naver-maps가 지도를 파괴/재생성하며 크래시한다(KVO.destroy null 등).
+  // 지도 엘리먼트를 메모이즈해 참조를 고정하면 React가 이 서브트리 재조정을 건너뛴다.
+  const mapElement = useMemo(() => {
+    if (!hasMap) {
+      return null;
+    }
+
+    return (
+      <PreviewMapWithProvider
+        ncpKeyId={X_NCP_APIGW_API_KEY_ID}
+        latitude={location.latitude as number}
+        longitude={location.longitude as number}
+        name={profile.name}
+        isAppWebview={checkIsWebView()}
+      />
+    );
+  }, [hasMap, location?.latitude, location?.longitude, profile.name]);
+
   const handleCopyAddress = async () => {
     if (!addressText) {
       return;
@@ -159,15 +178,7 @@ const HomeTab = ({ profile }: Props) => {
               복사
             </Styled.CopyButton>
           </Styled.AddressLine>
-          {hasMap && (
-            <PreviewMapWithProvider
-              ncpKeyId={X_NCP_APIGW_API_KEY_ID}
-              latitude={location.latitude as number}
-              longitude={location.longitude as number}
-              name={profile.name}
-              isAppWebview={checkIsWebView()}
-            />
-          )}
+          {mapElement}
         </Styled.Section>
       )}
       </Styled.Container>

--- a/apps/place/src/components/NotFound/index.tsx
+++ b/apps/place/src/components/NotFound/index.tsx
@@ -1,0 +1,34 @@
+import styled from '@emotion/styled';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  height: 290px;
+  width: 100%;
+`;
+
+const Title = styled.span`
+  font-family: 'SB Aggro';
+  font-size: 20px;
+  line-height: 30px;
+  letter-spacing: -0.6px;
+  color: ${({ theme }) => theme.palette.mobile.grey.g20};
+`;
+
+const Description = styled.span`
+  font-size: 16px;
+  line-height: 24px;
+  color: ${({ theme }) => theme.palette.mobile.grey.g30};
+`;
+
+const NotFound = () => (
+  <Container>
+    <Title>NOT FOUND</Title>
+    <Description>페이지를 찾을 수 없어요.</Description>
+  </Container>
+);
+
+export default NotFound;

--- a/apps/place/src/pages/NotFoundPage/index.tsx
+++ b/apps/place/src/pages/NotFoundPage/index.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import Error from '~/components/Error';
+import NotFound from '~/components/NotFound';
 import Layout from '~/components/Layout';
 
 const Center = styled.div`
@@ -10,12 +10,12 @@ const Center = styled.div`
   min-height: 100dvh;
 `;
 
-const ErrorPage = () => (
+const NotFoundPage = () => (
   <Layout>
     <Center>
-      <Error />
+      <NotFound />
     </Center>
   </Layout>
 );
 
-export default ErrorPage;
+export default NotFoundPage;

--- a/apps/place/vite.config.ts
+++ b/apps/place/vite.config.ts
@@ -7,7 +7,14 @@ export default defineConfig({
     alias: [{ find: '~', replacement: '/src' }],
   },
   server: {
+    // 네이버 지도 등 boolti.in 도메인에 등록된 키/인증을 로컬에서 그대로 쓰기 위해
+    // place.dev.boolti.in 호스트로 띄운다. (/etc/hosts에 127.0.0.1 매핑 필요)
     port: 8083,
+    host: 'place.dev.boolti.in',
+    https: {
+      key: './place.dev.boolti.in-key.pem',
+      cert: './place.dev.boolti.in.pem',
+    },
     // 로컬 개발 시 dev API의 CORS 제한을 우회하기 위한 프록시.
     // .env.local에서 VITE_BASE_API_URL을 비워두면 요청이 프록시를 타게 된다.
     proxy: {


### PR DESCRIPTION
## 개요

place 앱의 네이버 지도 크래시 수정과 404·에러 페이지 분리, 그리고 로컬에서 지도 인증이 통과되도록 dev 서버 호스트를 정리합니다.

## 변경 사항

### 1. `fix(place)` 갤러리 모달 열 때 네이버 지도 크래시 수정
- 이미지 클릭 → `HomeTab` 리렌더 시 지도 서브트리까지 리렌더되며 `react-naver-maps`가 지도를 파괴/재생성 → `KVO.destroy` null 등으로 크래시.
- 지도 엘리먼트를 `useMemo`로 메모이즈해 참조를 고정, React가 해당 서브트리 재조정을 건너뛰도록 함(지도는 최초 1회만 마운트).

### 2. `feat(place)` 404·에러 페이지 분리 및 추가
- 기존에는 미매칭 경로와 런타임/쿼리 에러가 모두 `ComingSoon` 화면으로 처리됨.
- `ComingSoon` 톤에 맞춘 `NotFound`·`Error` 컴포넌트 추가.
- 라우팅 분리: 미매칭 경로(`*`) → 404, `errorElement` → 에러 페이지.

### 3. `chore(place)` dev 서버를 `place.dev.boolti.in` HTTPS 호스트로 구동
- localhost origin은 네이버 지도 키에 미등록이라 `/v3/auth` 401 → 지도 미표시.
- admin·preview와 동일하게 boolti.in 계열 호스트로 띄워 등록된 키/인증을 로컬에서 그대로 사용.
- **로컬 실행 준비**: `/etc/hosts`에 `127.0.0.1 place.dev.boolti.in` 추가 + `mkcert place.dev.boolti.in`로 인증서 생성(`apps/place/`, gitignore).

## 확인

- `place.dev.boolti.in` 호스트에서 네이버 지도 `/v3/auth` 200 확인.
- `turbo type-check --filter=place` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)