### PR TITLE
fix(admin): 미등록 공연장 주소검색을 다음 우편번호+네이버 지오코딩으로 전환

### DIFF
--- a/apps/admin/src/components/PlaceSearchInput/AddressSearchDialogContent.tsx
+++ b/apps/admin/src/components/PlaceSearchInput/AddressSearchDialogContent.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useRef } from 'react';
+
+const POSTCODE_SCRIPT_URL = '//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js';
+
+interface DaumPostcodeData {
+  roadAddress: string;
+  address: string;
+  zonecode: string;
+}
+
+interface DaumPostcodeConstructor {
+  new (options: {
+    oncomplete: (data: DaumPostcodeData) => void;
+    width: string | number;
+    height: string | number;
+  }): { embed: (element: HTMLElement) => void };
+}
+
+declare global {
+  interface Window {
+    daum?: { Postcode: DaumPostcodeConstructor };
+  }
+}
+
+let scriptPromise: Promise<void> | null = null;
+
+const loadPostcodeScript = () => {
+  if (window.daum?.Postcode) {
+    return Promise.resolve();
+  }
+  if (!scriptPromise) {
+    scriptPromise = new Promise<void>((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = POSTCODE_SCRIPT_URL;
+      script.onload = () => resolve();
+      script.onerror = () => {
+        scriptPromise = null;
+        reject(new Error('우편번호 스크립트 로드 실패'));
+      };
+      document.head.appendChild(script);
+    });
+  }
+  return scriptPromise;
+};
+
+interface AddressSearchDialogContentProps {
+  /** 도로명주소 선택 시 호출. 좌표 변환은 호출 측(PlaceSearchInput)에서 처리한다. */
+  onComplete: (roadAddress: string) => void;
+}
+
+// 다음 우편번호 서비스를 다이얼로그 안에 embed 하고, 선택한 도로명주소를 상위로 전달한다.
+const AddressSearchDialogContent = ({ onComplete }: AddressSearchDialogContentProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    loadPostcodeScript()
+      .then(() => {
+        if (cancelled || !containerRef.current || !window.daum?.Postcode) {
+          return;
+        }
+        containerRef.current.innerHTML = '';
+        new window.daum.Postcode({
+          width: '100%',
+          height: '100%',
+          oncomplete: (data) => onComplete(data.roadAddress || data.address),
+        }).embed(containerRef.current);
+      })
+      .catch(() => {
+        // 스크립트 로드 실패는 조용히 무시한다. 사용자는 공연장명 검색으로 대체 가능.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [onComplete]);
+
+  return <div ref={containerRef} style={{ width: '100%', height: 466 }} />;
+};
+
+export default AddressSearchDialogContent;

--- a/apps/admin/src/components/PlaceSearchInput/PlaceSearchInput.styles.ts
+++ b/apps/admin/src/components/PlaceSearchInput/PlaceSearchInput.styles.ts
@@ -106,11 +106,6 @@ const PlaceName = styled.span`
   color: ${({ theme }) => theme.palette.grey.g90};
 `;
 
-const Category = styled.span`
-  ${({ theme }) => theme.typo.b1};
-  color: ${({ theme }) => theme.palette.grey.g40};
-`;
-
 const AddressName = styled.span`
   ${({ theme }) => theme.typo.b1};
   color: ${({ theme }) => theme.palette.grey.g50};
@@ -171,7 +166,6 @@ export default {
   DropdownItem,
   PlaceNameRow,
   PlaceName,
-  Category,
   AddressName,
   SelectedInfo,
   ErrorMessage,

--- a/apps/admin/src/components/PlaceSearchInput/PlaceSearchInput.test.tsx
+++ b/apps/admin/src/components/PlaceSearchInput/PlaceSearchInput.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ThemeProvider } from '@emotion/react';
 import breakpoint from '@boolti/ui/src/systems/breakpoint';
 import palette from '@boolti/ui/src/systems/palette';
@@ -7,8 +7,15 @@ import typo from '@boolti/ui/src/systems/typo';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import React from 'react';
 
+const { dialogOpenMock, dialogCloseMock, toastErrorMock, geocodeMock } = vi.hoisted(() => ({
+  dialogOpenMock: vi.fn(),
+  dialogCloseMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  geocodeMock: vi.fn(),
+}));
+
 // @boolti/ui transitively imports swiper, which Yarn PnP can't resolve in tests.
-// Stub TextField — that's the only thing PlaceSearchInput uses from @boolti/ui.
+// Stub the pieces PlaceSearchInput uses from @boolti/ui.
 vi.mock('@boolti/ui', () => ({
   TextField: React.forwardRef<
     HTMLInputElement,
@@ -18,6 +25,13 @@ vi.mock('@boolti/ui', () => ({
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { inputType: _inputType, size: _size, ...rest } = props;
     return <input ref={ref} {...rest} />;
+  }),
+  useDialog: () => ({ open: dialogOpenMock, close: dialogCloseMock, isOpen: false, id: 'test' }),
+  useToast: () => ({
+    error: toastErrorMock,
+    success: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
   }),
   mq_lg: '@media (min-width: 1024px)',
   mq_md: '@media (min-width: 768px)',
@@ -33,6 +47,7 @@ vi.mock('@boolti/api', async (importOriginal) => {
   return {
     ...actual,
     useConcertHallProfile: vi.fn(),
+    useNaverGeocode: () => geocodeMock,
   };
 });
 
@@ -45,13 +60,25 @@ const theme = { palette, typo, breakpoint };
 const renderWith = (ui: React.ReactElement) =>
   render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
 
+const mockConcertHallProfile = (
+  data: unknown = undefined,
+  overrides: Partial<{ isLoading: boolean; isError: boolean }> = {},
+) => {
+  vi.mocked(apiModule.useConcertHallProfile).mockReturnValue({
+    data,
+    isLoading: false,
+    isError: false,
+    ...overrides,
+  } as unknown as ReturnType<typeof apiModule.useConcertHallProfile>);
+};
+
 describe('PlaceSearchInput', () => {
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
   });
 
-  it('불티 검색 결과를 "불티 등록 공연장" 섹션 헤더 아래에 배지와 함께 표시', async () => {
+  it('불티 검색 결과를 "불티 등록 공연장" 섹션 헤더 아래에 배지와 함께 표시하고, 주소 직접 검색 진입점을 항상 제공', async () => {
     vi.spyOn(useVenueSearchModule, 'default').mockReturnValue({
       query: '롤링홀',
       setQuery: vi.fn(),
@@ -63,31 +90,19 @@ describe('PlaceSearchInput', () => {
           name: '롤링홀',
           address: '서울 마포구 와우산로 21길 19',
         },
-        {
-          source: 'kakao_place',
-          placeName: '클럽 FF',
-          category: '문화시설',
-          addressName: '서울 마포구',
-          roadAddressName: '서울 마포구 와우산로 13길 25',
-          x: '126.92',
-          y: '37.55',
-        },
       ],
       isLoading: false,
       errors: {},
     } as ReturnType<typeof useVenueSearchModule.default>);
 
-    vi.mocked(apiModule.useConcertHallProfile).mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      isError: false,
-    } as unknown as ReturnType<typeof apiModule.useConcertHallProfile>);
+    mockConcertHallProfile();
 
     renderWith(<PlaceSearchInput onSelect={vi.fn()} />);
     fireEvent.focus(screen.getByPlaceholderText(/공연장명 또는 도로명 주소/));
     expect(screen.getByText('불티 등록 공연장')).not.toBeNull();
-    expect(screen.getByText('외부 검색 결과')).not.toBeNull();
     expect(screen.getByText('불티 등록')).not.toBeNull();
+    // 등록 안 된 공연장을 위한 주소 직접 검색 진입점은 항상 노출된다.
+    expect(screen.getByText('주소로 직접 검색하기')).not.toBeNull();
   });
 
   it('불티 결과 클릭 시 getProfile 호출 후 onSelect에 concertHallId 포함', async () => {
@@ -102,22 +117,18 @@ describe('PlaceSearchInput', () => {
       errors: {},
     } as ReturnType<typeof useVenueSearchModule.default>);
 
-    vi.mocked(apiModule.useConcertHallProfile).mockReturnValue({
-      data: {
-        id: 1,
-        name: '롤링홀',
-        head: {
-          location: {
-            streetAddress: '서울 마포구 와우산로 21길 19',
-            detailAddress: '지하 1층',
-            latitude: 37.55,
-            longitude: 126.923,
-          },
+    mockConcertHallProfile({
+      id: 1,
+      name: '롤링홀',
+      head: {
+        location: {
+          streetAddress: '서울 마포구 와우산로 21길 19',
+          detailAddress: '지하 1층',
+          latitude: 37.55,
+          longitude: 126.923,
         },
       },
-      isLoading: false,
-      isError: false,
-    } as unknown as ReturnType<typeof apiModule.useConcertHallProfile>);
+    });
 
     const handleSelect = vi.fn();
     renderWith(<PlaceSearchInput onSelect={handleSelect} />);
@@ -139,43 +150,93 @@ describe('PlaceSearchInput', () => {
     });
   });
 
-  it('카카오 address 결과 선택 시 상세 주소 입력 활성', async () => {
+  it('"주소로 직접 검색하기" 클릭 시 주소 찾기 다이얼로그를 연다', () => {
     vi.spyOn(useVenueSearchModule, 'default').mockReturnValue({
-      query: '와우산로',
+      query: '없는공연장',
       setQuery: vi.fn(),
       clearResults: vi.fn(),
-      results: [
-        {
-          source: 'kakao_address',
-          addressName: '서울 마포구 와우산로 18길 20',
-          roadAddressName: '서울 마포구 와우산로 18길 20',
-          x: '126.92',
-          y: '37.55',
-        },
-      ],
+      results: [],
       isLoading: false,
       errors: {},
     } as ReturnType<typeof useVenueSearchModule.default>);
 
-    vi.mocked(apiModule.useConcertHallProfile).mockReturnValue({
-      data: undefined,
+    mockConcertHallProfile();
+
+    renderWith(<PlaceSearchInput onSelect={vi.fn()} />);
+    fireEvent.focus(screen.getByPlaceholderText(/공연장명 또는 도로명 주소/));
+    fireEvent.click(screen.getByText('주소로 직접 검색하기'));
+
+    expect(dialogOpenMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('주소 선택 완료 시 네이버 지오코딩 좌표로 onSelect(type: address) 호출 및 상세주소 입력 활성', async () => {
+    vi.spyOn(useVenueSearchModule, 'default').mockReturnValue({
+      query: '없는공연장',
+      setQuery: vi.fn(),
+      clearResults: vi.fn(),
+      results: [],
       isLoading: false,
-      isError: false,
-    } as unknown as ReturnType<typeof apiModule.useConcertHallProfile>);
+      errors: {},
+    } as ReturnType<typeof useVenueSearchModule.default>);
+
+    mockConcertHallProfile();
+    geocodeMock.mockResolvedValue({ latitude: 37.5, longitude: 127.0 });
 
     const handleSelect = vi.fn();
     renderWith(<PlaceSearchInput onSelect={handleSelect} />);
     fireEvent.focus(screen.getByPlaceholderText(/공연장명 또는 도로명 주소/));
-    fireEvent.click(screen.getByText(/서울 마포구 와우산로 18길 20/));
+    fireEvent.click(screen.getByText('주소로 직접 검색하기'));
 
-    const detailInput = await screen.findByPlaceholderText('상세 주소를 입력해 주세요');
-    expect((detailInput as HTMLInputElement).disabled).toBe(false);
+    // 다이얼로그에 넘긴 컨텐츠의 onComplete 콜백을 직접 호출해 주소 선택을 시뮬레이션한다.
+    const openArg = dialogOpenMock.mock.calls[0][0];
+    const onComplete = (openArg.content as React.ReactElement<{ onComplete: (a: string) => void }>)
+      .props.onComplete;
+    await act(async () => {
+      await onComplete('서울 마포구 와우산로 18길 20');
+    });
+
+    expect(geocodeMock).toHaveBeenCalledWith('서울 마포구 와우산로 18길 20');
     expect(handleSelect).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'kakao_address',
+        type: 'address',
+        streetAddress: '서울 마포구 와우산로 18길 20',
+        latitude: 37.5,
+        longitude: 127.0,
       }),
     );
     const callArg = handleSelect.mock.calls[0][0];
     expect(callArg.concertHallId).toBeUndefined();
+
+    const detailInput = await screen.findByPlaceholderText('상세 주소를 입력해 주세요');
+    expect((detailInput as HTMLInputElement).disabled).toBe(false);
+  });
+
+  it('지오코딩 실패 시 토스트를 노출하고 onSelect를 호출하지 않는다', async () => {
+    vi.spyOn(useVenueSearchModule, 'default').mockReturnValue({
+      query: '없는공연장',
+      setQuery: vi.fn(),
+      clearResults: vi.fn(),
+      results: [],
+      isLoading: false,
+      errors: {},
+    } as ReturnType<typeof useVenueSearchModule.default>);
+
+    mockConcertHallProfile();
+    geocodeMock.mockResolvedValue(null);
+
+    const handleSelect = vi.fn();
+    renderWith(<PlaceSearchInput onSelect={handleSelect} />);
+    fireEvent.focus(screen.getByPlaceholderText(/공연장명 또는 도로명 주소/));
+    fireEvent.click(screen.getByText('주소로 직접 검색하기'));
+
+    const openArg = dialogOpenMock.mock.calls[0][0];
+    const onComplete = (openArg.content as React.ReactElement<{ onComplete: (a: string) => void }>)
+      .props.onComplete;
+    await act(async () => {
+      await onComplete('서울 마포구 와우산로 18길 20');
+    });
+
+    expect(toastErrorMock).toHaveBeenCalled();
+    expect(handleSelect).not.toHaveBeenCalled();
   });
 });

--- a/apps/admin/src/components/PlaceSearchInput/index.tsx
+++ b/apps/admin/src/components/PlaceSearchInput/index.tsx
@@ -1,13 +1,14 @@
-import { useConcertHallProfile } from '@boolti/api';
+import { useConcertHallProfile, useNaverGeocode } from '@boolti/api';
 import { SearchIcon } from '@boolti/icon';
-import { TextField } from '@boolti/ui';
-import { useEffect, useRef, useState } from 'react';
+import { TextField, useDialog, useToast } from '@boolti/ui';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import useVenueSearch, { VenueResult } from '~/hooks/useVenueSearch';
 
+import AddressSearchDialogContent from './AddressSearchDialogContent';
 import Styled from './PlaceSearchInput.styles';
 
-export type PlaceSelectType = 'boolti' | 'kakao_place' | 'kakao_address';
+export type PlaceSelectType = 'boolti' | 'address';
 
 export interface PlaceSelectResult {
   type: PlaceSelectType;
@@ -37,6 +38,8 @@ interface SelectedSnapshot {
   streetAddress: string;
 }
 
+const GEOCODE_FAILED_MESSAGE = '주소의 위치 정보를 가져오지 못했어요. 다른 주소로 다시 시도해 주세요.';
+
 const PlaceSearchInput = ({
   initialPlaceName,
   initialAddress,
@@ -57,21 +60,21 @@ const PlaceSearchInput = ({
   const detailAddressInputRef = useRef<HTMLInputElement>(null);
 
   const profileQuery = useConcertHallProfile(pendingBooltiId);
+  const geocode = useNaverGeocode();
+  const dialog = useDialog();
+  const toast = useToast();
 
   useEffect(() => {
     if (!selected && initialAddress) {
-      const type: PlaceSelectType = initialConcertHallId
-        ? 'boolti'
-        : initialPlaceName
-          ? 'kakao_place'
-          : 'kakao_address';
+      const type: PlaceSelectType = initialConcertHallId ? 'boolti' : 'address';
       setSelected({
         type,
         placeName: initialPlaceName ?? '',
         streetAddress: initialAddress,
       });
+      setQuery(initialPlaceName || initialAddress);
     }
-  }, [initialAddress, initialPlaceName, initialConcertHallId, selected]);
+  }, [initialAddress, initialPlaceName, initialConcertHallId, selected, setQuery]);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -151,43 +154,44 @@ const PlaceSearchInput = ({
     setPendingBooltiId(concertHallId);
   };
 
-  const handleSelectKakaoPlace = (
-    result: Extract<VenueResult, { source: 'kakao_place' }>,
-  ) => {
-    const street = result.roadAddressName || result.addressName;
-    setSelected({ type: 'kakao_place', placeName: result.placeName, streetAddress: street });
-    setDetailAddress('');
-    setQuery(result.placeName);
-    setIsDropdownOpen(false);
-    clearResults();
-    onSelect({
-      type: 'kakao_place',
-      placeName: result.placeName,
-      streetAddress: street,
-      detailAddress: '',
-      latitude: Number(result.y),
-      longitude: Number(result.x),
-    });
-  };
+  // 다음 우편번호 서비스로 선택한 도로명주소를 네이버 지오코딩으로 좌표 변환한다.
+  const handleAddressComplete = useCallback(
+    async (roadAddress: string) => {
+      dialog.close();
 
-  const handleSelectKakaoAddress = (
-    result: Extract<VenueResult, { source: 'kakao_address' }>,
-  ) => {
-    const street = result.roadAddressName || result.addressName;
-    setSelected({ type: 'kakao_address', placeName: '', streetAddress: street });
-    setDetailAddress('');
-    setQuery(street);
+      const coordinates = await geocode(roadAddress);
+      if (!coordinates) {
+        toast.error(GEOCODE_FAILED_MESSAGE);
+        return;
+      }
+
+      setSelected({ type: 'address', placeName: '', streetAddress: roadAddress });
+      setDetailAddress('');
+      setQuery(roadAddress);
+      setIsDropdownOpen(false);
+      clearResults();
+
+      onSelect({
+        type: 'address',
+        placeName: '',
+        streetAddress: roadAddress,
+        detailAddress: '',
+        latitude: coordinates.latitude,
+        longitude: coordinates.longitude,
+      });
+
+      setTimeout(() => detailAddressInputRef.current?.focus(), 0);
+    },
+    [dialog, geocode, toast, setQuery, clearResults, onSelect],
+  );
+
+  const openAddressSearch = () => {
     setIsDropdownOpen(false);
-    clearResults();
-    onSelect({
-      type: 'kakao_address',
-      placeName: '',
-      streetAddress: street,
-      detailAddress: '',
-      latitude: Number(result.y),
-      longitude: Number(result.x),
+    dialog.open({
+      title: '주소 찾기',
+      width: '490px',
+      content: <AddressSearchDialogContent onComplete={handleAddressComplete} />,
     });
-    setTimeout(() => detailAddressInputRef.current?.focus(), 0);
   };
 
   const handleDetailAddressChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -202,12 +206,6 @@ const PlaceSearchInput = ({
 
   const booltiResults = results.filter(
     (r): r is Extract<VenueResult, { source: 'boolti' }> => r.source === 'boolti',
-  );
-  const kakaoPlaceResults = results.filter(
-    (r): r is Extract<VenueResult, { source: 'kakao_place' }> => r.source === 'kakao_place',
-  );
-  const kakaoAddressResults = results.filter(
-    (r): r is Extract<VenueResult, { source: 'kakao_address' }> => r.source === 'kakao_address',
   );
 
   const showDropdown = isDropdownOpen && query.trim() && !selected;
@@ -231,67 +229,42 @@ const PlaceSearchInput = ({
 
         {showDropdown && (
           <Styled.Dropdown>
-            {isLoading && results.length === 0 ? (
-              <Styled.EmptyState>검색 중...</Styled.EmptyState>
-            ) : results.length === 0 ? (
-              <Styled.EmptyState>검색 결과가 없어요</Styled.EmptyState>
-            ) : (
+            {booltiResults.length > 0 && (
               <>
-                {booltiResults.length > 0 && (
-                  <>
-                    <Styled.SectionHeader>불티 등록 공연장</Styled.SectionHeader>
-                    {booltiResults.map((r) => (
-                      <Styled.DropdownItem
-                        key={`boolti-${r.concertHallId}`}
-                        onClick={() => handleSelectBoolti(r.concertHallId)}
-                      >
-                        <Styled.PlaceNameRow>
-                          <Styled.PlaceName>{r.name}</Styled.PlaceName>
-                          <Styled.BooltiBadge>불티 등록</Styled.BooltiBadge>
-                        </Styled.PlaceNameRow>
-                        <Styled.AddressName>{r.address}</Styled.AddressName>
-                      </Styled.DropdownItem>
-                    ))}
-                  </>
-                )}
-                {(kakaoPlaceResults.length > 0 || kakaoAddressResults.length > 0) && (
-                  <>
-                    <Styled.SectionHeader>외부 검색 결과</Styled.SectionHeader>
-                    {kakaoPlaceResults.map((r, i) => (
-                      <Styled.DropdownItem
-                        key={`kp-${i}-${r.x}-${r.y}`}
-                        onClick={() => handleSelectKakaoPlace(r)}
-                      >
-                        <Styled.PlaceNameRow>
-                          <Styled.PlaceName>{r.placeName}</Styled.PlaceName>
-                          {r.category && <Styled.Category>{r.category}</Styled.Category>}
-                        </Styled.PlaceNameRow>
-                        <Styled.AddressName>
-                          {r.roadAddressName || r.addressName}
-                        </Styled.AddressName>
-                      </Styled.DropdownItem>
-                    ))}
-                    {kakaoAddressResults.map((r, i) => (
-                      <Styled.DropdownItem
-                        key={`ka-${i}-${r.x}-${r.y}`}
-                        onClick={() => handleSelectKakaoAddress(r)}
-                      >
-                        <Styled.PlaceNameRow>
-                          <Styled.PlaceName>{r.roadAddressName || r.addressName}</Styled.PlaceName>
-                        </Styled.PlaceNameRow>
-                      </Styled.DropdownItem>
-                    ))}
-                  </>
-                )}
+                <Styled.SectionHeader>불티 등록 공연장</Styled.SectionHeader>
+                {booltiResults.map((r) => (
+                  <Styled.DropdownItem
+                    key={`boolti-${r.concertHallId}`}
+                    onClick={() => handleSelectBoolti(r.concertHallId)}
+                  >
+                    <Styled.PlaceNameRow>
+                      <Styled.PlaceName>{r.name}</Styled.PlaceName>
+                      <Styled.BooltiBadge>불티 등록</Styled.BooltiBadge>
+                    </Styled.PlaceNameRow>
+                    <Styled.AddressName>{r.address}</Styled.AddressName>
+                  </Styled.DropdownItem>
+                ))}
               </>
             )}
+            {isLoading && booltiResults.length === 0 && (
+              <Styled.EmptyState>검색 중...</Styled.EmptyState>
+            )}
+            <Styled.SectionHeader>외부 검색 결과</Styled.SectionHeader>
+            <Styled.DropdownItem onClick={openAddressSearch}>
+              <Styled.PlaceNameRow>
+                <Styled.PlaceName>주소로 직접 검색하기</Styled.PlaceName>
+              </Styled.PlaceNameRow>
+              <Styled.AddressName>
+                등록되지 않은 공연장은 도로명 주소로 검색해 주세요
+              </Styled.AddressName>
+            </Styled.DropdownItem>
           </Styled.Dropdown>
         )}
       </Styled.Container>
 
       {selected && (
         <Styled.SelectedInfo>
-          {selected.type === 'kakao_address' ? (
+          {selected.type === 'address' ? (
             <TextField
               ref={detailAddressInputRef}
               inputType="text"

--- a/apps/admin/src/hooks/useVenueSearch.test.ts
+++ b/apps/admin/src/hooks/useVenueSearch.test.ts
@@ -28,9 +28,6 @@ vi.mock('@boolti/api', async (importOriginal) => {
 
 import useVenueSearch from './useVenueSearch';
 
-const KAKAO_KEYWORD_URL = 'https://dapi.kakao.com/v2/local/search/keyword.json';
-const KAKAO_ADDRESS_URL = 'https://dapi.kakao.com/v2/local/search/address.json';
-
 const server = setupServer(
   http.get('*/web/v1/host/concert-halls', () =>
     HttpResponse.json({
@@ -42,48 +39,6 @@ const server = setupServer(
       totalElements: 1,
       totalPages: 1,
       hasNext: false,
-    }),
-  ),
-  http.get(KAKAO_KEYWORD_URL, () =>
-    HttpResponse.json({
-      documents: [
-        {
-          id: 'k1',
-          place_name: '롤링홀',
-          category_group_code: 'CT1',
-          category_group_name: '문화시설',
-          address_name: '서울 마포구 상수동',
-          road_address_name: '서울 마포구 와우산로 21길 19',
-          x: '126.923',
-          y: '37.55',
-          phone: '',
-        },
-        {
-          id: 'k2',
-          place_name: '클럽 FF',
-          category_group_code: 'CT1',
-          category_group_name: '문화시설',
-          address_name: '서울 마포구 와우산로 13길 25',
-          road_address_name: '서울 마포구 와우산로 13길 25',
-          x: '126.92',
-          y: '37.55',
-          phone: '',
-        },
-      ],
-    }),
-  ),
-  http.get(KAKAO_ADDRESS_URL, () =>
-    HttpResponse.json({
-      documents: [
-        {
-          address_name: '서울 마포구 와우산로 18길 20',
-          address_type: 'ROAD_ADDR',
-          x: '126.92',
-          y: '37.55',
-          address: null,
-          road_address: { address_name: '서울 마포구 와우산로 18길 20', road_name: '와우산로 18길', building_name: '' },
-        },
-      ],
     }),
   ),
 );
@@ -99,7 +54,7 @@ describe('useVenueSearch', () => {
     expect(result.current.isLoading).toBe(false);
   });
 
-  it('검색어 입력 후 디바운싱 거쳐 세 소스 결과 머지', async () => {
+  it('검색어 입력 후 디바운싱 거쳐 불티 등록 공연장 결과 반환', async () => {
     // NOTE: Real timers are used here because fake timers interact poorly with
     // fetch + MSW + setTimeout-based debouncing under jsdom. waitFor polls until
     // the debounced search completes.
@@ -116,20 +71,15 @@ describe('useVenueSearch', () => {
       { timeout: 3000 },
     );
 
-    const sources = result.current.results.map((r) => r.source);
-    expect(sources).toContain('boolti');
-    // 카카오 place 중 '롤링홀'은 불티와 이름 일치로 제외돼야 함
-    const kakaoPlaceNames = result.current.results
-      .filter((r) => r.source === 'kakao_place')
-      .map((r) => (r as { placeName: string }).placeName);
-    expect(kakaoPlaceNames).not.toContain('롤링홀');
-    expect(kakaoPlaceNames).toContain('클럽 FF');
-
-    // 불티가 맨 위에 와야 함
-    expect(result.current.results[0].source).toBe('boolti');
+    expect(result.current.results.every((r) => r.source === 'boolti')).toBe(true);
+    expect(result.current.results[0]).toMatchObject({
+      source: 'boolti',
+      concertHallId: 1,
+      name: '롤링홀',
+    });
   });
 
-  it('한 소스가 실패해도 나머지 결과는 표시', async () => {
+  it('불티 검색 실패 시 빈 결과와 boolti 에러를 반환', async () => {
     server.use(
       http.get('*/web/v1/host/concert-halls', () =>
         HttpResponse.json({ message: 'server error' }, { status: 500 }),
@@ -144,12 +94,11 @@ describe('useVenueSearch', () => {
 
     await waitFor(
       () => {
-        const hasKakao = result.current.results.some((r) => r.source.startsWith('kakao'));
-        expect(hasKakao).toBe(true);
+        expect(result.current.errors?.boolti).toBeTruthy();
       },
       { timeout: 3000 },
     );
 
-    expect(result.current.errors?.boolti).toBeTruthy();
+    expect(result.current.results).toEqual([]);
   });
 });

--- a/apps/admin/src/hooks/useVenueSearch.ts
+++ b/apps/admin/src/hooks/useVenueSearch.ts
@@ -1,62 +1,21 @@
 import { fetcher, WebHostConcertHallListResponse } from '@boolti/api';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-const KAKAO_REST_API_KEY = import.meta.env.VITE_KAKAO_REST_API_KEY;
-const KAKAO_LOCAL_KEYWORD_URL = 'https://dapi.kakao.com/v2/local/search/keyword.json';
-const KAKAO_LOCAL_ADDRESS_URL = 'https://dapi.kakao.com/v2/local/search/address.json';
-
 const DEBOUNCE_MS = 300;
-const KAKAO_PAGE_SIZE = 5;
 const BOOLTI_PAGE_SIZE = 5;
 
-interface KakaoKeywordDoc {
-  id: string;
-  place_name: string;
-  category_group_name: string;
-  address_name: string;
-  road_address_name: string;
-  x: string;
-  y: string;
-}
+export type VenueSource = 'boolti';
 
-interface KakaoAddressDoc {
-  address_name: string;
-  x: string;
-  y: string;
-  address: { address_name: string } | null;
-  road_address: { address_name: string } | null;
-}
-
-export type VenueSource = 'boolti' | 'kakao_place' | 'kakao_address';
-
-export type VenueResult =
-  | {
-      source: 'boolti';
-      concertHallId: number;
-      name: string;
-      address: string;
-    }
-  | {
-      source: 'kakao_place';
-      placeName: string;
-      addressName: string;
-      roadAddressName: string;
-      category: string;
-      x: string;
-      y: string;
-    }
-  | {
-      source: 'kakao_address';
-      addressName: string;
-      roadAddressName: string;
-      x: string;
-      y: string;
-    };
+// 불티에 등록된 공연장 검색 결과. 등록되지 않은 공연장은 PlaceSearchInput의
+// 다음 우편번호 서비스 + 네이버 지오코딩(주소 직접 검색)으로 처리한다.
+export type VenueResult = {
+  source: 'boolti';
+  concertHallId: number;
+  name: string;
+  address: string;
+};
 
 // fetcher (ky) automatically attaches the access token and refreshes on 401.
-// Note: AbortSignal isn't passed into kakao fetch because jsdom's signal class
-// trips an instanceof check inside node's fetch impl; stale responses are
-// filtered out via the controller.signal.aborted check after allSettled.
 const fetchBoolti = async (keyword: string): Promise<VenueResult[]> => {
   const data = await fetcher.get<WebHostConcertHallListResponse>('web/v1/host/concert-halls', {
     searchParams: { keyword, page: 0, size: BOOLTI_PAGE_SIZE },
@@ -67,64 +26,6 @@ const fetchBoolti = async (keyword: string): Promise<VenueResult[]> => {
     name: item.name,
     address: item.address,
   }));
-};
-
-const fetchKakaoKeyword = async (keyword: string): Promise<VenueResult[]> => {
-  const url = new URL(KAKAO_LOCAL_KEYWORD_URL);
-  url.searchParams.set('query', keyword);
-  url.searchParams.set('size', String(KAKAO_PAGE_SIZE));
-
-  const res = await fetch(url.toString(), {
-    headers: { Authorization: `KakaoAK ${KAKAO_REST_API_KEY}` },
-  });
-  if (!res.ok) throw new Error(`kakao_place ${res.status}`);
-  const data = (await res.json()) as { documents: KakaoKeywordDoc[] };
-  return data.documents.map((doc) => ({
-    source: 'kakao_place' as const,
-    placeName: doc.place_name,
-    category: doc.category_group_name,
-    addressName: doc.address_name,
-    roadAddressName: doc.road_address_name,
-    x: doc.x,
-    y: doc.y,
-  }));
-};
-
-const fetchKakaoAddress = async (keyword: string): Promise<VenueResult[]> => {
-  const url = new URL(KAKAO_LOCAL_ADDRESS_URL);
-  url.searchParams.set('query', keyword);
-  url.searchParams.set('size', String(KAKAO_PAGE_SIZE));
-
-  const res = await fetch(url.toString(), {
-    headers: { Authorization: `KakaoAK ${KAKAO_REST_API_KEY}` },
-  });
-  if (!res.ok) throw new Error(`kakao_address ${res.status}`);
-  const data = (await res.json()) as { documents: KakaoAddressDoc[] };
-  return data.documents.map((doc) => ({
-    source: 'kakao_address' as const,
-    addressName: doc.address?.address_name ?? doc.address_name,
-    roadAddressName: doc.road_address?.address_name ?? doc.address_name,
-    x: doc.x,
-    y: doc.y,
-  }));
-};
-
-const normalizeName = (name: string) => name.trim().toLowerCase();
-
-const merge = (
-  boolti: VenueResult[],
-  kakaoPlace: VenueResult[],
-  kakaoAddress: VenueResult[],
-): VenueResult[] => {
-  const booltiNames = new Set(
-    boolti
-      .filter((r): r is Extract<VenueResult, { source: 'boolti' }> => r.source === 'boolti')
-      .map((r) => normalizeName(r.name)),
-  );
-  const filteredKakaoPlace = kakaoPlace.filter(
-    (r) => r.source === 'kakao_place' && !booltiNames.has(normalizeName(r.placeName)),
-  );
-  return [...boolti, ...filteredKakaoPlace, ...kakaoAddress];
 };
 
 const useVenueSearch = () => {
@@ -150,25 +51,18 @@ const useVenueSearch = () => {
     setIsLoading(true);
     setErrors({});
 
-    const settled = await Promise.allSettled([
-      fetchBoolti(keyword),
-      fetchKakaoKeyword(keyword),
-      fetchKakaoAddress(keyword),
-    ]);
-
-    if (controller.signal.aborted) return;
-
-    const nextErrors: Partial<Record<VenueSource, Error>> = {};
-    const sourceMap: VenueSource[] = ['boolti', 'kakao_place', 'kakao_address'];
-    const sourceResults: VenueResult[][] = settled.map((s, i) => {
-      if (s.status === 'fulfilled') return s.value;
-      nextErrors[sourceMap[i]] = s.reason instanceof Error ? s.reason : new Error(String(s.reason));
-      return [];
-    });
-
-    setResults(merge(sourceResults[0], sourceResults[1], sourceResults[2]));
-    setErrors(nextErrors);
-    setIsLoading(false);
+    try {
+      const booltiResults = await fetchBoolti(keyword);
+      if (controller.signal.aborted) return;
+      setResults(booltiResults);
+      setErrors({});
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      setResults([]);
+      setErrors({ boolti: error instanceof Error ? error : new Error(String(error)) });
+    } finally {
+      if (!controller.signal.aborted) setIsLoading(false);
+    }
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## 문제
공연 등록 화면의 주소검색에서 **불티 등록 공연장만 검색**되고, 등록되지 않은 공연장은 검색되지 않았습니다.

## 근본 원인
카카오 앱의 **OPEN_MAP_AND_LOCAL(지도/로컬) 서비스가 비활성화**되어 `useVenueSearch`의 카카오 REST 로컬 검색(keyword/address)이 전부 403으로 실패했습니다. 코드가 실패를 catch해 빈 배열을 반환하므로 불티 결과만 남았습니다.

```
403 {"errorType":"NotAuthorizedError","message":"App(불티) disabled OPEN_MAP_AND_LOCAL service."}
```

외부 서비스 설정 이슈이며, 조직이 이미 지도/주소 기능을 카카오→네이버로 마이그레이션 중이라 super-admin과 동일한 패턴으로 전환했습니다.

## 변경 사항
- **`useVenueSearch`**: 카카오 fetch/merge 제거, 불티 등록 공연장 검색만 유지
- **`AddressSearchDialogContent`(신규)**: 다음 우편번호 서비스 embed (무료·키 불필요)
- **`PlaceSearchInput`**: 드롭다운에 **"주소로 직접 검색하기"** 진입점 상시 노출 → 다음 우편번호 팝업 → `useNaverGeocode`(백엔드 프록시 `web/v1/naver-maps/geocoding`)로 좌표 변환 → `type: 'address'`. 지오코딩 실패 시 토스트 안내
- 테스트 갱신 (불티 / 주소검색 진입 / 다이얼로그 오픈 / 지오코딩 성공·실패)

## 동작
- 불티 등록 공연장: 기존처럼 인라인 드롭다운 선택
- **미등록 공연장: 도로명 주소로 직접 검색** → 상세주소 입력

> 참고: 네이버 프록시는 지오코딩만 제공(장소명 키워드 검색 엔드포인트 없음)하므로 미등록 공연장은 **주소 기반 검색만** 가능합니다.

## 검증
- ✅ `yarn type-check` 통과
- ✅ `yarn lint` 0 errors
- ✅ 관련 유닛 테스트 8개 통과 (Landing 통합 테스트 1건 실패는 본 변경 이전부터 존재하던 무관한 이슈)

🤖 Generated with [Claude Code](https://claude.com/claude-code)