### PR TITLE
style(landing): 데스크탑 헤더 좌우 여백을 80px에서 60px로 변경

### DIFF
--- a/apps/admin/src/pages/Landing/components/Header/Header.styles.ts
+++ b/apps/admin/src/pages/Landing/components/Header/Header.styles.ts
@@ -19,7 +19,7 @@ const Header = styled.header<{ hideBorder?: boolean }>`
   }
 
   ${mq_desktop} {
-    padding: 0 80px;
+    padding: 0 60px;
   }
 `;
 


### PR DESCRIPTION
## 변경 사항

랜딩페이지 헤더의 데스크탑(1200px 이상) 좌우 padding을 `80px` → `60px` 로 변경했습니다.

- `apps/admin/src/pages/Landing/components/Header/Header.styles.ts`
- 모바일(24px), 태블릿(48px) 여백은 그대로 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)