### PR TITLE
fix(place): 임베드 페이지에서 접기 후 웹뷰 높이가 안 줄어드는 문제 수정

### DIFF
--- a/apps/place/src/components/Layout/index.tsx
+++ b/apps/place/src/components/Layout/index.tsx
@@ -1,29 +1,33 @@
 import styled from '@emotion/styled';
 
 // 모바일 웹뷰 기준 화면. 데스크탑에서는 최대 너비를 고정하고 가운데 정렬한다.
-const Container = styled.div`
+const Container = styled.div<{ fillViewport: boolean }>`
   display: flex;
   justify-content: center;
   width: 100%;
-  min-height: 100dvh;
+  ${({ fillViewport }) => fillViewport && 'min-height: 100dvh;'}
   background-color: ${({ theme }) => theme.palette.mobile.grey.g95};
 `;
 
-const ContentWrapper = styled.div`
+const ContentWrapper = styled.div<{ fillViewport: boolean }>`
   position: relative;
   width: 100%;
   max-width: 680px;
-  min-height: 100dvh;
+  ${({ fillViewport }) => fillViewport && 'min-height: 100dvh;'}
   background-color: ${({ theme }) => theme.palette.mobile.grey.g95};
 `;
 
 interface Props {
   children: React.ReactNode;
+  // 네이티브 앱이 콘텐츠 높이에 맞춰 웹뷰 프레임을 리사이즈하는 임베드 페이지에서는
+  // min-height: 100dvh가 "그 시점의 웹뷰 프레임 높이"를 기준으로 계산되어, 한 번 늘어난
+  // 높이 아래로는 다시 줄어들지 못하는 피드백 루프를 만든다. 이런 페이지는 false로 끈다.
+  fillViewport?: boolean;
 }
 
-const Layout = ({ children }: Props) => (
-  <Container>
-    <ContentWrapper>{children}</ContentWrapper>
+const Layout = ({ children, fillViewport = true }: Props) => (
+  <Container fillViewport={fillViewport}>
+    <ContentWrapper fillViewport={fillViewport}>{children}</ContentWrapper>
   </Container>
 );
 

--- a/apps/place/src/pages/ConcertHallTabPage/index.tsx
+++ b/apps/place/src/pages/ConcertHallTabPage/index.tsx
@@ -28,14 +28,14 @@ const ConcertHallTabPage = ({ tab }: Props) => {
   }, [profile?.name, profile?.share?.title]);
 
   if (!profile) {
-    return <Layout>{null}</Layout>;
+    return <Layout fillViewport={false}>{null}</Layout>;
   }
 
   const hasTabData = tab === 'home' ? profile.hasHomeTabData : profile.hasRentalTabData;
   const updatedAtText = formatUpdatedAt(profile.informationUpdatedAt);
 
   return (
-    <Layout>
+    <Layout fillViewport={false}>
       {hasTabData ? (
         tab === 'home' ? (
           <HomeTab profile={profile} />


### PR DESCRIPTION
## Summary
- `/:concertHallId/home`, `/:concertHallId/rental`(네이티브 웹뷰 임베드용)에서 "내용 더 보기"로 펼친 뒤 다시 접어도 웹뷰 높이가 펼친 상태로 고정되는 버그 수정
- 원인: `Layout`의 `min-height: 100dvh`가 그 시점의 웹뷰 프레임 높이를 기준으로 계산되어, 네이티브가 콘텐츠 높이에 맞춰 프레임을 키운 뒤에는 다시 줄어들지 못하는 피드백 루프를 만듦
- `Layout`에 `fillViewport` prop(기본 `true`)을 추가하고, 콘텐츠 높이 기준으로 auto-resize되어야 하는 `ConcertHallTabPage`에서만 `false`로 꺼서 순수 콘텐츠 높이가 `scrollHeight`에 반영되도록 함
- `/:concertHallId` 풀페이지, `NotFoundPage`, `ErrorPage`는 기존 동작(뷰포트 최소 높이 유지) 그대로 유지

## Test plan
- [x] `tsc --noEmit`, `vite build` 통과 확인
- [x] Playwright로 API 응답을 목업해 실제 접기/펼치기 흐름 재현: `bodyScrollHeight` 496 → (펼침) 1044 → (접음) 496으로 정상 복귀 확인 (수정 전에는 접어도 1044에 고정)
- [ ] 실기기 네이티브 웹뷰에서 홈/대관정보 탭 "내용 더 보기 → 접기" 시 웹뷰 높이가 실제로 줄어드는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)