### PR TITLE
fix(landing): 랜딩 QA(26-07-31) 반영 - 헤더 색상/로고 크기/띠배너 색상

### DIFF
--- a/apps/admin/src/pages/Landing/LandingPage.styles.ts
+++ b/apps/admin/src/pages/Landing/LandingPage.styles.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { m } from 'framer-motion';
 
-import { mq_desktop, mq_lg } from './constants';
+import { LANDING_COLORS, mq_desktop, mq_lg } from './constants';
 
 const Container = styled(m.div)`
   overflow-x: clip;
@@ -19,6 +19,7 @@ const TopBar = styled.div`
   z-index: 20;
   display: flex;
   flex-direction: column;
+  background-color: ${LANDING_COLORS.topBarBackdrop};
 `;
 
 const FooterContainer = styled.div`

--- a/apps/admin/src/pages/Landing/components/Header/Header.styles.ts
+++ b/apps/admin/src/pages/Landing/components/Header/Header.styles.ts
@@ -41,16 +41,12 @@ const HeaderContaienr = styled.div`
 `;
 
 const BooltiIcon = styled.button`
-  width: 55.5px;
-  height: 21px;
+  width: 74px;
+  height: 28px;
   cursor: pointer;
   display: flex;
   align-items: center;
 
-  ${mq_lg} {
-    width: 74px;
-    height: 28px;
-  }
   & > svg {
     width: 100%;
     height: 100%;

--- a/apps/admin/src/pages/Landing/constants.ts
+++ b/apps/admin/src/pages/Landing/constants.ts
@@ -18,11 +18,14 @@ export const LANDING_COLORS = {
   darkCardBg: '#A2A5B4',
   headerGlass: 'rgba(111, 116, 133, 0.4)',
   headerBorder: 'rgba(136, 141, 157, 0.3)',
+  // sticky 헤더가 얹히는 배경. 최상단에서도 glass 가 히어로(#131343) 위에 합성되도록 하여
+  // 시안(Nav #363858)과 동일한 다크 네이비로 보이게 함
+  topBarBackdrop: '#131343',
   cardBorder: '#D8DBE5',
   promoGradient: 'linear-gradient(180deg, #FFE6DF 0%, #F3F5F9 100%)',
   paymentGradient: 'linear-gradient(180deg, #E9EBFE 0%, #F3F5F9 100%)',
   // 공연장 찾기 띠배너 (Figma 디자인 토큰 기준: Primary/O01 #FF6827, Grey/G50 #6F7485)
-  spaceBannerBg: '#E5E7F2',
+  spaceBannerBg: '#E8E6FB',
   spaceBannerStrongText: '#090D43',
   spaceBannerSubText: '#6F7485',
   // top variant: 주황 배경 + 네이비 글자


### PR DESCRIPTION
## 개요
Figma 랜딩페이지 1차 QA (26-07-31) 반영. 시안과 실제 렌더를 비교해 4건 중 3건을 코드 수정, 1건은 이미 반영된 항목으로 확인.

## 변경 사항

### 1. Nav바 최상단 색상 (QA: 최상단일 때 색상이 시안과 다름)
- 원인: sticky 헤더가 최상단에서 **흰 페이지 배경** 위에 glass 로 합성돼 `#C5C7CE` 회색으로 렌더됨
- 조치: 헤더가 얹히는 `TopBar` 에 히어로 상단색(`#131343`) 배경을 깔아, glass 가 **히어로 위**에서 내는 시안값 그대로(`#37395D` ≈ 시안 `#363858`) 보이게 함
- 헤더 glass 토큰 자체는 변경하지 않음 (해당 토큰은 히어로 위에서 이미 시안값을 냄)

### 2. 모바일 로고 크기 (QA: 불티 로고가 시안보다 작아 보임)
- `BooltiIcon` 모바일 크기를 `55.5×21` → **`74×28`** (데스크탑과 동일, 시안 로고 높이 ≈ 27px 측정치와 일치)

### 3. 공연장 찾기 띠배너 배경색 (QA: 상단 띠배너 색상 확인)
- `spaceBannerBg` `#E5E7F2`(회색끼) → **`#E8E6FB`** (Figma Banner fill 실제값)

## 이미 반영되어 변경 없음
### 4. 모바일 햄버거 메뉴 (QA: 햄버거 메뉴 누락)
- 햄버거 + 드롭다운은 `QA 1차 반영`(2026-04-24)부터 존재하며, 라이브 렌더에서도 정상 표시됨. QA 구현본 스크린샷에도 햄버거가 찍혀 있어 **이미 반영된 항목으로 판단** → 코드 변경 없음

## 검증
- 로컬 렌더(모바일/데스크탑, 최상단) 스크린샷으로 시안 대비 확인
- `type-check` 통과, `lint` 에러 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)