### PR TITLE
feat(place): 앱 웹뷰에서 사진 화면을 앱으로 넘기는 브릿지 추가

### DIFF
--- a/apps/place/src/components/HomeTab/index.tsx
+++ b/apps/place/src/components/HomeTab/index.tsx
@@ -1,5 +1,5 @@
-import type { ConcertHallProfileResponse } from '@boolti/api';
-import { checkIsWebView } from '@boolti/bridge';
+import { type ConcertHallProfileResponse, useConcertHallImages } from '@boolti/api';
+import { checkIsWebView, isWebViewBridgeAvailable, viewPlacePhotoDetail } from '@boolti/bridge';
 import { ChevronDownIcon, ChevronUpIcon } from '@boolti/icon';
 import { PreviewMapWithProvider, useToast } from '@boolti/ui';
 import { useLayoutEffect, useMemo, useRef, useState } from 'react';
@@ -75,6 +75,10 @@ const HomeTab = ({ profile }: Props) => {
   const home = profile.home;
   const [gallery, setGallery] = useState<{ mode: GalleryMode; index: number } | null>(null);
 
+  // 앱 웹뷰에서는 사진 화면을 앱이 띄우므로, 넘겨줄 전체 사진 ID를 미리 조회해 둔다
+  const isAppWebView = isWebViewBridgeAvailable();
+  const { data: allImages } = useConcertHallImages(profile.id, isAppWebView);
+
   // 미리보기 장수는 백엔드가 제어(최대 5장)하고, 전체는 갤러리 모달에서 별도 조회한다.
   const visibleImages = home?.images ?? [];
   const totalImageCount = home?.totalImageCount ?? visibleImages.length;
@@ -105,6 +109,24 @@ const HomeTab = ({ profile }: Props) => {
     );
   }, [hasMap, location?.latitude, location?.longitude, profile.name]);
 
+  // 앱 웹뷰에서는 사진 목록/뷰어를 앱 네이티브 화면이 담당하므로 브릿지로 넘긴다
+  const handlePhotoClick = (index: number, showMoreOverlay: boolean) => {
+    if (isAppWebView) {
+      const images = allImages?.items ?? visibleImages;
+
+      viewPlacePhotoDetail({
+        id: profile.id,
+        imageIds: images.map((image) => image.id),
+      }).catch(() => {
+        // 앱이 응답하지 않아도 웹에서 할 수 있는 처리는 없다
+      });
+
+      return;
+    }
+
+    setGallery(showMoreOverlay ? { mode: 'list', index: 0 } : { mode: 'viewer', index });
+  };
+
   const handleCopyAddress = async () => {
     if (!addressText) {
       return;
@@ -134,11 +156,7 @@ const HomeTab = ({ profile }: Props) => {
                 <Styled.PhotoItem
                   key={image.id}
                   type="button"
-                  onClick={() =>
-                    setGallery(
-                      showMoreOverlay ? { mode: 'list', index: 0 } : { mode: 'viewer', index },
-                    )
-                  }
+                  onClick={() => handlePhotoClick(index, showMoreOverlay)}
                 >
                   <Styled.PhotoImage
                     src={image.thumbnailUrl || image.imageUrl}

--- a/packages/bridge/src/commands/index.ts
+++ b/packages/bridge/src/commands/index.ts
@@ -2,3 +2,4 @@ export * from './navigateBack';
 export * from './navigateToShowDetail';
 export * from './requestToken';
 export * from './showToast';
+export * from './viewPlacePhotoDetail';

--- a/packages/bridge/src/commands/viewPlacePhotoDetail.ts
+++ b/packages/bridge/src/commands/viewPlacePhotoDetail.ts
@@ -1,0 +1,12 @@
+import { sendCommand } from './sendCommand';
+
+export type ViewPlacePhotoDetailRequestData = {
+  /** 공연장(플레이스) ID */
+  id: number;
+  /** 전체 사진 ID 목록 (노출 순서대로) */
+  imageIds: number[];
+};
+
+export const viewPlacePhotoDetail = (data: ViewPlacePhotoDetailRequestData) => {
+  return sendCommand({ command: 'VIEW_PLACE_PHOTO_DETAIL', data });
+};

--- a/packages/bridge/src/types.ts
+++ b/packages/bridge/src/types.ts
@@ -2,7 +2,8 @@ export type WebviewCommand =
   | 'NAVIGATE_TO_SHOW_DETAIL'
   | 'NAVIGATE_BACK'
   | 'REQUEST_TOKEN'
-  | 'SHOW_TOAST';
+  | 'SHOW_TOAST'
+  | 'VIEW_PLACE_PHOTO_DETAIL';
 
 export type BaseCommand = {
   id: string;


### PR DESCRIPTION
## 배경

플레이스(공연장 프로필)를 앱 내 웹뷰로 띄울 때, 사진 목록/뷰어 화면은 앱 네이티브가 담당해야 합니다.

## 변경 사항

- `@boolti/bridge`에 `VIEW_PLACE_PHOTO_DETAIL` 커맨드 추가
- 홈 탭 사진 썸네일을 탭하면, 앱 웹뷰에서는 갤러리 모달 대신 브릿지로 앱에 전달
- 전체 사진 ID 목록을 함께 보내기 위해 웹뷰일 때만 이미지 목록 쿼리를 미리 조회 (로딩 전이면 미리보기 5장 ID로 폴백)
- 웹 브라우저에서는 기존 갤러리 모달 동작 그대로

## 전송 포맷

기존 커맨드와 동일한 봉투이며 `command`/`data`만 다릅니다.

```json
{
  "id": "<uuid>",
  "timestamp": "<ms 문자열>",
  "command": "VIEW_PLACE_PHOTO_DETAIL",
  "data": {
    "id": 2,
    "imageIds": [11, 12, 13, 14, 15, 16]
  }
}
```

- `data.id`: 공연장(플레이스) ID
- `data.imageIds`: 전체 사진 ID, 노출 순서대로
- 채널: Android `window.boolti.postMessage`, iOS `window.webkit.messageHandlers.boolti.postMessage`
- 응답은 기다리지 않습니다 (1초 타임아웃 reject 무시)

## 확인

- `turbo type-check`, `turbo lint` (place, @boolti/bridge) 통과
- 실기기 웹뷰 동작은 앱 대응 후 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)