### PR TITLE
feat(super-admin): 공연장 상권/지역 API 연동 및 공연장 ID 입력 추가

### DIFF
--- a/apps/super-admin/src/pages/ConcertHallInfoPage/index.tsx
+++ b/apps/super-admin/src/pages/ConcertHallInfoPage/index.tsx
@@ -36,6 +36,8 @@ const MAX_PHOTO_COUNT = 20;
 
 const PHONE_NUMBER_REGEX = /^0\d{1,2}-?\d{3,4}-?\d{4}$/;
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+/** 공연장 ID(공유 코드): 영문 소문자·숫자·하이픈 1~20자 */
+const SHARE_CODE_REGEX = /^[a-z0-9-]{1,20}$/;
 
 const AmenityIcon = ({ src, label }: { src: string; label: string }) => (
   <img src={src} alt={label} style={{ width: 18, height: 18, verticalAlign: 'middle' }} />
@@ -122,6 +124,7 @@ const ConcertHallInfoPage = () => {
 
   // 기본 정보
   const [name, setName] = useState('');
+  const [shareCode, setShareCode] = useState('');
   const [streetAddress, setStreetAddress] = useState('');
   const [detailAddress, setDetailAddress] = useState('');
   const [latitude, setLatitude] = useState<number | undefined>(undefined);
@@ -148,6 +151,7 @@ const ConcertHallInfoPage = () => {
       return;
     }
     setName(detail.name ?? '');
+    setShareCode(detail.shareCode ?? '');
     setStreetAddress(detail.location?.streetAddress ?? '');
     setDetailAddress(detail.location?.detailAddress ?? '');
     setLatitude(detail.location?.latitude);
@@ -228,6 +232,7 @@ const ConcertHallInfoPage = () => {
     });
   };
 
+  const hasShareCodeError = shareCode.length > 0 && !SHARE_CODE_REGEX.test(shareCode);
   const hasPhoneNumberError = phoneNumber.length > 0 && !PHONE_NUMBER_REGEX.test(phoneNumber);
   const hasEmailError = email.length > 0 && !EMAIL_REGEX.test(email);
 
@@ -245,6 +250,10 @@ const ConcertHallInfoPage = () => {
   };
 
   const onSave = async () => {
+    if (!shareCode || hasShareCodeError) {
+      toast.error('공연장 ID를 확인해 주세요.');
+      return;
+    }
     if (hasPhoneNumberError || hasEmailError) {
       toast.error('전화번호/이메일 형식을 확인해 주세요.');
       return;
@@ -259,8 +268,7 @@ const ConcertHallInfoPage = () => {
         hallId,
         body: {
           name: name.trim(),
-          // 공유 코드는 이 화면에서 수정하지 않지만 저장 시 필수라 조회값을 그대로 보낸다
-          shareCode: detail?.shareCode ?? '',
+          shareCode,
           introduction: introduction.trim() || undefined,
           representativeImageUrl,
           location: {
@@ -382,6 +390,24 @@ const ConcertHallInfoPage = () => {
             <div>
               <FieldLabel>공연장명</FieldLabel>
               <Input size="large" value={name} onChange={(e) => setName(e.target.value)} />
+            </div>
+            <div>
+              <FieldLabel>
+                공연장 ID <Typography.Text type="danger">*</Typography.Text>
+              </FieldLabel>
+              <Input
+                size="large"
+                value={shareCode}
+                maxLength={20}
+                placeholder="영문 소문자, 숫자, 하이픈만 입력해 주세요"
+                status={hasShareCodeError ? 'error' : undefined}
+                onChange={(e) => setShareCode(e.target.value)}
+              />
+              {hasShareCodeError && (
+                <Typography.Text type="danger" style={{ display: 'block', marginTop: 4 }}>
+                  영문 소문자, 숫자, 하이픈만 1~20자로 입력할 수 있어요.
+                </Typography.Text>
+              )}
             </div>
             <div>
               <FieldLabel>공연장 주소</FieldLabel>

--- a/apps/super-admin/src/pages/ConcertHallInfoPage/index.tsx
+++ b/apps/super-admin/src/pages/ConcertHallInfoPage/index.tsx
@@ -1,6 +1,7 @@
 import { CloseOutlined, PlusOutlined } from '@ant-design/icons';
 import {
   useSuperAdminConcertHallDetail,
+  useSuperAdminConcertHallRegionGroups,
   useSuperAdminConcertHallSubwayStations,
   useSuperAdminSaveConcertHallSubwayStations,
   useSuperAdminUpdateConcertHall,
@@ -67,63 +68,6 @@ const INITIAL_AMENITIES: AmenitiesState = {
   hasAlcoholSales: false,
 };
 
-// 백엔드 데이터 인터페이스 확정 전이라 UI 작업용 임시 목록. 값은 저장 API에는 포함하지 않는다.
-const BUSINESS_DISTRICT_OPTIONS = [
-  {
-    label: '서북',
-    options: [
-      { value: '홍대/연남/연희', label: '홍대/연남/연희' },
-      { value: '합정/상수/망원', label: '합정/상수/망원' },
-      { value: '신촌/이대/서대문', label: '신촌/이대/서대문' },
-      { value: '공덕/아현/도화', label: '공덕/아현/도화' },
-      { value: '연신내/불광/은평', label: '연신내/불광/은평' },
-    ],
-  },
-  {
-    label: '도심',
-    options: [
-      { value: '을지로/충무로/명동', label: '을지로/충무로/명동' },
-      { value: '종로/삼청/서북/북촌', label: '종로/삼청/서북/북촌' },
-      { value: '혜화/대학로/성북', label: '혜화/대학로/성북' },
-      { value: '이태원/한남/해방촌', label: '이태원/한남/해방촌' },
-      { value: '용산/삼각지', label: '용산/삼각지' },
-    ],
-  },
-  {
-    label: '강남',
-    options: [
-      { value: '강남/논현/역삼', label: '강남/논현/역삼' },
-      { value: '압구정/청담/도산', label: '압구정/청담/도산' },
-      { value: '신사/잠원', label: '신사/잠원' },
-      { value: '서초/교대/방배', label: '서초/교대/방배' },
-      { value: '잠실/방이', label: '잠실/방이' },
-      { value: '천호/강동', label: '천호/강동' },
-    ],
-  },
-  {
-    label: '동북',
-    options: [
-      { value: '성수/서울숲/뚝섬', label: '성수/서울숲/뚝섬' },
-      { value: '구의/건대/자양', label: '구의/건대/자양' },
-      { value: '왕십리/동대문', label: '왕십리/동대문' },
-      { value: '노원/수유', label: '노원/수유' },
-    ],
-  },
-  {
-    label: '서남',
-    options: [
-      { value: '여의도/영등포/문래', label: '여의도/영등포/문래' },
-      { value: '신도림/구로', label: '신도림/구로' },
-      { value: '서울대입구/신림', label: '서울대입구/신림' },
-      { value: '목동/강서/마곡', label: '목동/강서/마곡' },
-    ],
-  },
-  {
-    label: '미분류',
-    options: [{ value: '기타', label: '기타' }],
-  },
-];
-
 const FieldLabel = ({ children }: { children: React.ReactNode }) => (
   <Typography.Text strong style={{ display: 'block', marginBottom: 8 }}>
     {children}
@@ -171,6 +115,7 @@ const ConcertHallInfoPage = () => {
 
   const { data: detail } = useSuperAdminConcertHallDetail(hallId);
   const { data: savedStations } = useSuperAdminConcertHallSubwayStations(hallId);
+  const { data: regionGroups } = useSuperAdminConcertHallRegionGroups();
   const saveSubwayStations = useSuperAdminSaveConcertHallSubwayStations();
   const updateConcertHall = useSuperAdminUpdateConcertHall();
   const uploadImage = useSuperAdminUploadConcertHallImage();
@@ -181,8 +126,7 @@ const ConcertHallInfoPage = () => {
   const [detailAddress, setDetailAddress] = useState('');
   const [latitude, setLatitude] = useState<number | undefined>(undefined);
   const [longitude, setLongitude] = useState<number | undefined>(undefined);
-  // 백엔드 데이터 인터페이스가 아직 없어 UI만 먼저 작업 (저장 API 미연동)
-  const [businessDistrict, setBusinessDistrict] = useState<string | undefined>(undefined);
+  const [regionId, setRegionId] = useState<number | null>(null);
   const [stations, setStations] = useState<SelectedStation[]>([]);
   const [representativeImage, setRepresentativeImage] = useState<string | null>(null);
 
@@ -208,6 +152,7 @@ const ConcertHallInfoPage = () => {
     setDetailAddress(detail.location?.detailAddress ?? '');
     setLatitude(detail.location?.latitude);
     setLongitude(detail.location?.longitude);
+    setRegionId(detail.region?.regionId ?? null);
     setRepresentativeImage(detail.representativeImageUrl ?? null);
     setWebsiteUrl(detail.contact?.websiteUrl ?? '');
     setPhoneNumber(detail.contact?.phoneNumber ?? '');
@@ -314,6 +259,8 @@ const ConcertHallInfoPage = () => {
         hallId,
         body: {
           name: name.trim(),
+          // 공유 코드는 이 화면에서 수정하지 않지만 저장 시 필수라 조회값을 그대로 보낸다
+          shareCode: detail?.shareCode ?? '',
           introduction: introduction.trim() || undefined,
           representativeImageUrl,
           location: {
@@ -323,6 +270,8 @@ const ConcertHallInfoPage = () => {
             latitude,
             longitude,
           },
+          // 선택 해제 시 null을 보내야 서버에서 지역이 해제된다
+          regionId,
           contact: {
             websiteUrl: websiteUrl.trim() || undefined,
             phoneNumber: phoneNumber.trim() || undefined,
@@ -342,6 +291,16 @@ const ConcertHallInfoPage = () => {
       toast.error('저장 중 문제가 발생했습니다.');
     }
   };
+
+  // 상권/지역은 그룹 > 지역 2단계 그룹 옵션으로 노출한다 (둘 다 sequence 오름차순)
+  const regionOptions = [...(regionGroups ?? [])]
+    .sort((a, b) => a.sequence - b.sequence)
+    .map((group) => ({
+      label: group.name,
+      options: [...group.regions]
+        .sort((a, b) => a.sequence - b.sequence)
+        .map((region) => ({ value: region.regionId, label: region.name })),
+    }));
 
   const countAmenityItems: Array<{
     key: 'hasWaitingRoom' | 'hasParking' | 'hasCabinet';
@@ -460,9 +419,9 @@ const ConcertHallInfoPage = () => {
                 size="large"
                 style={{ width: '100%', height: 48 }}
                 placeholder="상권/지역을 선택해 주세요"
-                value={businessDistrict}
-                onChange={setBusinessDistrict}
-                options={BUSINESS_DISTRICT_OPTIONS}
+                value={regionId ?? undefined}
+                onChange={(value?: number) => setRegionId(value ?? null)}
+                options={regionOptions}
                 showSearch
                 optionFilterProp="label"
                 allowClear

--- a/packages/api/src/queries/index.ts
+++ b/packages/api/src/queries/index.ts
@@ -67,6 +67,7 @@ import useConcertHallRecommendedRegions from './useConcertHallRecommendedRegions
 import useConcertHallAutocomplete from './useConcertHallAutocomplete';
 import useSuperAdminConcertHallList from './useSuperAdminConcertHallList';
 import useSuperAdminConcertHallDetail from './useSuperAdminConcertHallDetail';
+import useSuperAdminConcertHallRegionGroups from './useSuperAdminConcertHallRegionGroups';
 import useSuperAdminConcertHallRental from './useSuperAdminConcertHallRental';
 import useSuperAdminConcertHallSubwayStations from './useSuperAdminConcertHallSubwayStations';
 import useSuperAdminConcertHallShows from './useSuperAdminConcertHallShows';
@@ -145,6 +146,7 @@ export {
   useConcertHallAutocomplete,
   useSuperAdminConcertHallList,
   useSuperAdminConcertHallDetail,
+  useSuperAdminConcertHallRegionGroups,
   useSuperAdminConcertHallRental,
   useSuperAdminConcertHallSubwayStations,
   useSuperAdminConcertHallShows,

--- a/packages/api/src/queries/useSuperAdminConcertHallRegionGroups.ts
+++ b/packages/api/src/queries/useSuperAdminConcertHallRegionGroups.ts
@@ -1,0 +1,8 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { queryKeys } from '../queryKey';
+
+const useSuperAdminConcertHallRegionGroups = () =>
+  useQuery(queryKeys.superAdminConcertHall.regionGroups);
+
+export default useSuperAdminConcertHallRegionGroups;

--- a/packages/api/src/queryKey.ts
+++ b/packages/api/src/queryKey.ts
@@ -56,6 +56,7 @@ import {
   SubwayStationSearchItem,
   SuperAdminConcertHallDetailResponse,
   SuperAdminConcertHallListResponse,
+  SuperAdminConcertHallRegionGroup,
   SuperAdminConcertHallRentalResponse,
   SuperAdminConcertHallShowListResponse,
   SuperAdminConcertHallShowSortBy,
@@ -684,6 +685,11 @@ export const superAdminConcertHallQueryKeys = createQueryKeys('superAdminConcert
     queryFn: () =>
       fetcher.get<SuperAdminConcertHallDetailResponse>(`sa-api/v1/concert-halls/${hallId}`),
   }),
+  regionGroups: {
+    queryKey: null,
+    queryFn: () =>
+      fetcher.get<SuperAdminConcertHallRegionGroup[]>('sa-api/v1/concert-hall-region-groups'),
+  },
   rental: (hallId: number) => ({
     queryKey: [hallId],
     queryFn: () =>

--- a/packages/api/src/types/superAdminConcertHall.ts
+++ b/packages/api/src/types/superAdminConcertHall.ts
@@ -86,6 +86,32 @@ export interface SuperAdminConcertHallImage {
 }
 
 /** GET /concert-halls/{id} — 공연장 기본 정보 상세 (대관 정보는 별도 엔드포인트로 분리됨) */
+/** 공연장에 지정된 상권/지역 */
+export interface SuperAdminConcertHallRegion {
+  regionId: number;
+  /** 지역명 (예: 홍대/연남/연희) */
+  name: string;
+  groupId: number;
+  /** 지역 그룹명 (예: 서북) */
+  groupName: string;
+}
+
+export interface SuperAdminConcertHallRegionItem {
+  regionId: number;
+  name: string;
+  /** 그룹 내 노출 순서 */
+  sequence: number;
+}
+
+/** GET /concert-hall-region-groups — 상권/지역 그룹 목록 */
+export interface SuperAdminConcertHallRegionGroup {
+  groupId: number;
+  name: string;
+  /** 그룹 노출 순서 */
+  sequence: number;
+  regions: SuperAdminConcertHallRegionItem[];
+}
+
 export interface SuperAdminConcertHallDetailResponse {
   id: number;
   name: string;
@@ -97,6 +123,8 @@ export interface SuperAdminConcertHallDetailResponse {
   location?: SuperAdminConcertHallLocation;
   contact?: SuperAdminConcertHallContact;
   amenities?: SuperAdminConcertHallAmenities;
+  /** 지정된 상권/지역이 없으면 null */
+  region?: SuperAdminConcertHallRegion | null;
   /** ISO8601 */
   informationUpdatedAt?: string;
   hasHomeTabData?: boolean;
@@ -205,6 +233,10 @@ export interface SuperAdminConcertHallUpdateImage {
 /** PUT /concert-halls/{id} — 공연장 정보 수정 (대관 정보는 별도 엔드포인트) */
 export interface SuperAdminConcertHallUpdateRequest {
   name: string;
+  /** 공유 코드 (소문자·숫자, 최대 20자) */
+  shareCode: string;
+  /** 상권/지역 ID. null이면 지역 선택 해제 */
+  regionId?: number | null;
   introduction?: string;
   representativeImageUrl?: string;
   location?: SuperAdminConcertHallLocation;


### PR DESCRIPTION
## 변경 사항

### 1. 상권/지역 API 연동
- 상권/지역 그룹 목록 조회 API 추가 (`GET /sa-api/v1/concert-hall-region-groups`) — `useSuperAdminConcertHallRegionGroups`
- 공연장 정보 화면의 상권/지역 선택을 임시 로컬 상수(`BUSINESS_DISTRICT_OPTIONS`)에서 실제 API 목록으로 교체
- 옵션은 그룹 > 지역 2단계로, 그룹·지역 모두 `sequence` 오름차순 정렬
- 상세 조회의 `region.regionId`로 초기값을 채우고, 저장 시 `regionId`로 전송 (선택 해제 시 `null`)

### 2. 공연장 ID(공유 코드) 입력 UI
- 공연장명 아래에 필수 입력 필드 추가 ([피그마](https://www.figma.com/design/BGDkTB99yxqkaQrwlCdtU5/Boolti-Vol.2?node-id=10557-62463&m=dev))
- 상세 조회의 `shareCode`로 초기화, 저장 시 입력값을 그대로 전송
- 검증: 영문 소문자·숫자·하이픈 1~20자. 비어 있거나 형식이 어긋나면 저장 중단

### 3. 타입 반영
- `SuperAdminConcertHallDetailResponse`에 `region` 추가
- `SuperAdminConcertHallUpdateRequest`에 `shareCode`(필수), `regionId` 추가

## 참고

현재 dev 서버 스펙의 `shareCode` 패턴은 `^[a-z0-9]+$`로 하이픈을 허용하지 않지만, **하이픈을 허용하도록 백엔드에서 변경 예정**입니다. 클라이언트는 피그마 주석대로 영문 소문자·숫자·하이픈 1~20자로 검증합니다.

## 테스트

- `turbo type-check`, `turbo lint` (super-admin, @boolti/api) 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
