### PR TITLE
fix(admin): 공연 등록 실패 시 에러 안내 및 제출 중 상태 처리

### DIFF
--- a/apps/admin/src/pages/ShowAddPage/index.tsx
+++ b/apps/admin/src/pages/ShowAddPage/index.tsx
@@ -49,6 +49,7 @@ const stepItems = [
 ] as const;
 
 const SHOW_ADD_SUCCESS_MESSAGE = '공연을 등록했어요.';
+const SHOW_ADD_FAIL_MESSAGE = '공연을 등록하지 못했어요. 잠시 후 다시 시도해 주세요.';
 
 interface ShowAddPageProps {
   step: 'basic' | 'detail' | 'sales' | 'preQuestion';
@@ -84,6 +85,17 @@ const ShowAddPage = ({ step }: ShowAddPageProps) => {
 
   const toast = useToast();
   const confirm = useConfirm();
+
+  const isSubmittingShow =
+    uploadShowImageMutation.status === 'loading' || addShowMutation.status === 'loading';
+  const isSubmittingNonTicketingShow =
+    uploadShowImageMutation.status === 'loading' ||
+    addNonTicketingShowMutation.status === 'loading';
+
+  const onFailAddShow = (error: unknown) => {
+    console.error(error);
+    toast.error(SHOW_ADD_FAIL_MESSAGE);
+  };
 
   const onSuccessAddShow = (showId: number) => {
     if (isWebView && isWebViewBridgeAvailable()) {
@@ -138,17 +150,21 @@ const ShowAddPage = ({ step }: ShowAddPageProps) => {
       return;
     }
 
-    if (
-      uploadShowImageMutation.status === 'loading' ||
-      addNonTicketingShowMutation.status === 'loading'
-    ) {
+    if (isSubmittingNonTicketingShow) {
       return;
     }
 
-    const body = await getBasicBody();
-    const showId = await addNonTicketingShowMutation.mutateAsync({ ...body, isNonTicketing: true });
+    try {
+      const body = await getBasicBody();
+      const showId = await addNonTicketingShowMutation.mutateAsync({
+        ...body,
+        isNonTicketing: true,
+      });
 
-    onSuccessAddShow(showId);
+      onSuccessAddShow(showId);
+    } catch (error) {
+      onFailAddShow(error);
+    }
   };
 
   const onSubmitSalesInfoForm: SubmitHandler<ShowSalesInfoFormInputs> = async () => {
@@ -156,8 +172,7 @@ const ShowAddPage = ({ step }: ShowAddPageProps) => {
   };
 
   const onSubmitPreQuestionForm = async () => {
-    if (uploadShowImageMutation.status === 'loading' || addShowMutation.status === 'loading')
-      return;
+    if (isSubmittingShow) return;
     const hasEmptyPreQuestion = preQuestionList.some((q) => q.questionText.trim().length === 0);
     const hasOverLimitPreQuestion = preQuestionList.some(
       (q) => q.questionText.length > 100 || (q.description?.length ?? 0) > 100,
@@ -167,36 +182,40 @@ const ShowAddPage = ({ step }: ShowAddPageProps) => {
       return;
     }
 
-    const body = await getBasicBody();
-    const ticketBody = {
-      salesStartTime: `${showSalesInfoForm.getValues('startDate')}T00:00:00.000Z`,
-      salesEndTime: `${showSalesInfoForm.getValues('endDate')}T23:59:59.000Z`,
-      ticketNotice: `${showSalesInfoForm.getValues('ticketNotice') ?? ''}`,
-      salesTickets: salesTicketList.map((ticket) => ({
-        ticketName: ticket.name,
-        price: ticket.price,
-        totalForSale: ticket.quantity,
-      })),
-      invitationTickets: invitationTicketList.map((ticket) => ({
-        ticketName: ticket.name,
-        totalForSale: ticket.quantity,
-      })),
-      ...(preQuestionList.filter((q) => q.questionText.trim()).length > 0
-        ? {
-            preQuestions: preQuestionList
-              .filter((q) => q.questionText.trim())
-              .map((preQuestion, index) => ({
-                questionText: preQuestion.questionText,
-                description: preQuestion.description ?? '',
-                isRequired: preQuestion.isRequired,
-                sequence: index + 1,
-              })),
-          }
-        : {}),
-    };
-    const showId = await addShowMutation.mutateAsync({ ...body, ...ticketBody });
+    try {
+      const body = await getBasicBody();
+      const ticketBody = {
+        salesStartTime: `${showSalesInfoForm.getValues('startDate')}T00:00:00.000Z`,
+        salesEndTime: `${showSalesInfoForm.getValues('endDate')}T23:59:59.000Z`,
+        ticketNotice: `${showSalesInfoForm.getValues('ticketNotice') ?? ''}`,
+        salesTickets: salesTicketList.map((ticket) => ({
+          ticketName: ticket.name,
+          price: ticket.price,
+          totalForSale: ticket.quantity,
+        })),
+        invitationTickets: invitationTicketList.map((ticket) => ({
+          ticketName: ticket.name,
+          totalForSale: ticket.quantity,
+        })),
+        ...(preQuestionList.filter((q) => q.questionText.trim()).length > 0
+          ? {
+              preQuestions: preQuestionList
+                .filter((q) => q.questionText.trim())
+                .map((preQuestion, index) => ({
+                  questionText: preQuestion.questionText,
+                  description: preQuestion.description ?? '',
+                  isRequired: preQuestion.isRequired,
+                  sequence: index + 1,
+                })),
+            }
+          : {}),
+      };
+      const showId = await addShowMutation.mutateAsync({ ...body, ...ticketBody });
 
-    onSuccessAddShow(showId);
+      onSuccessAddShow(showId);
+    } catch (error) {
+      onFailAddShow(error);
+    }
   };
 
   const basicStepContent = (
@@ -284,10 +303,16 @@ const ShowAddPage = ({ step }: ShowAddPageProps) => {
             colorTheme="primary"
             size="bold"
             disabled={
-              !showDetailInfoForm.formState.isDirty || !showDetailInfoForm.formState.isValid
+              !showDetailInfoForm.formState.isDirty ||
+              !showDetailInfoForm.formState.isValid ||
+              isSubmittingNonTicketingShow
             }
           >
-            {isNonTicketingShow ? '공연 등록 완료하기' : '다음으로'}
+            {isNonTicketingShow
+              ? isSubmittingNonTicketingShow
+                ? '등록 중...'
+                : '공연 등록 완료하기'
+              : '다음으로'}
           </Styled.ShowAddFormButton>
         </Styled.ShowAddFormButtonContainer>
       </Styled.ShowAddForm>
@@ -332,13 +357,10 @@ const ShowAddPage = ({ step }: ShowAddPageProps) => {
                 toast.success('일반 티켓을 생성했어요.');
               }}
               onDeleteTicket={async (ticket) => {
-                const result = await confirm(
-                  '삭제한 티켓은 복구할 수 없어요. 삭제하시겠어요?',
-                  {
-                    cancel: '취소하기',
-                    confirm: '삭제하기',
-                  },
-                );
+                const result = await confirm('삭제한 티켓은 복구할 수 없어요. 삭제하시겠어요?', {
+                  cancel: '취소하기',
+                  confirm: '삭제하기',
+                });
 
                 if (!result) return;
 
@@ -371,13 +393,10 @@ const ShowAddPage = ({ step }: ShowAddPageProps) => {
                 toast.success('초청 티켓을 생성했어요.');
               }}
               onDeleteTicket={async (ticket) => {
-                const result = await confirm(
-                  '삭제한 티켓은 복구할 수 없어요. 삭제하시겠어요?',
-                  {
-                    cancel: '취소하기',
-                    confirm: '삭제하기',
-                  },
-                );
+                const result = await confirm('삭제한 티켓은 복구할 수 없어요. 삭제하시겠어요?', {
+                  cancel: '취소하기',
+                  confirm: '삭제하기',
+                });
 
                 if (!result) return;
 
@@ -538,10 +557,10 @@ const ShowAddPage = ({ step }: ShowAddPageProps) => {
             type="button"
             colorTheme="primary"
             size="bold"
-            disabled={!isPreQuestionFormValid}
+            disabled={!isPreQuestionFormValid || isSubmittingShow}
             onClick={onSubmitPreQuestionForm}
           >
-            공연 등록 완료하기
+            {isSubmittingShow ? '등록 중...' : '공연 등록 완료하기'}
           </Styled.ShowAddFormButton>
         </Styled.ShowAddFormButtonContainer>
       </Styled.ShowAddForm>


### PR DESCRIPTION
## 문제

2026-08-19 오전, 주최자가 PC에서 공연 등록 마지막(사전 질문) 단계에서 **CTA를 눌러도 아무 반응이 없다**는 문의가 들어왔다.

실제 원인은 서버 앞단 WAF(ModSecurity 932130) 오탐으로 `POST /web/v1/host/shows`가 403으로 차단된 것이었다(→ team-fire-squirrel/boolti-api#388). 다만 **어떤 이유로 실패하든 사용자에게는 "먹통"으로만 보이는** 프론트 문제가 함께 있었다.

`ShowAddPage`의 제출 핸들러에 예외 처리가 없어 요청이 실패하면 unhandled rejection으로 조용히 삼켜지고, 토스트도 로딩 표시도 뜨지 않는다.

```ts
const body = await getBasicBody();          // 실패 시 여기서 그대로 reject
const showId = await addShowMutation.mutateAsync({ ...body, ...ticketBody });
onSuccessAddShow(showId);
```

그 결과 사용자는 버튼을 계속 눌렀고, 서버에는 이미지 업로드 URL 발급 요청이 **180건(45회 재시도 × 4)** 쌓였다.

## 변경

- 티켓 판매 공연 / 미판매 공연 등록 경로 모두 `try-catch`로 감싸고 실패 시 토스트 노출
  - `공연을 등록하지 못했어요. 잠시 후 다시 시도해 주세요.`
  - 원본 에러는 `console.error`로 남겨 디버깅 가능하게 유지
- 제출 중에는 버튼을 비활성화하고 라벨을 `등록 중...`으로 변경해 중복 요청 방지

## 테스트

- [ ] 공연 등록 정상 완료 (기존 동작 유지)
- [ ] 등록 요청 실패 시 에러 토스트 노출 + 버튼 재활성화
- [ ] 제출 중 버튼 비활성화 / `등록 중...` 표시
- [ ] 티켓 미판매(FREE) 공연 등록도 동일하게 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)