### PR TITLE
fix(super-admin): 공연 데이터 삭제 모달 문구 수정

### DIFF
--- a/apps/super-admin/src/pages/ConcertHallDataPage/DeleteShowConfirmModal.tsx
+++ b/apps/super-admin/src/pages/ConcertHallDataPage/DeleteShowConfirmModal.tsx
@@ -51,7 +51,7 @@ const DeleteShowConfirmModal = ({
 
   return (
     <Modal
-      title="공연 삭제"
+      title="공연 데이터 삭제"
       open={open}
       onCancel={close}
       footer={
@@ -68,8 +68,9 @@ const DeleteShowConfirmModal = ({
       }
     >
       <Typography.Paragraph style={{ marginTop: 16 }}>
-        공연을 삭제하시려면 정확한 공연명을 입력해 주세요.
-        <br />* 삭제 시 작성했던 공연 정보는 전부 사라지며 복구할 수 없어요.
+        공연장과 연결된 공연 데이터를 삭제하려면 정확한 공연명을 입력해 주세요.
+        <br />* ‘직접 입력’ 방식으로 추가한 공연 데이터와의 연결을 해제하는 경우, 해당 공연에 대한
+        데이터가 모두 사라지며 복구할 수 없어요.
       </Typography.Paragraph>
       <Flex vertical gap={8} style={{ marginBottom: 8 }}>
         <Input


### PR DESCRIPTION
## 배경

[피그마 코멘트](https://www.figma.com/design/BGDkTB99yxqkaQrwlCdtU5/Boolti-Vol.2?node-id=9223-143120&m=dev)에서 "개념이 약간 잘못 들어가 있어서 헤더 텍스트와 디스크립션을 수정했다"는 요청이 있었습니다. 공연 자체를 지우는 게 아니라 공연장과 연결된 공연 데이터를 지우는 동작이라는 점이 드러나야 합니다.

## 변경 사항

`apps/super-admin/src/pages/ConcertHallDataPage/DeleteShowConfirmModal.tsx` 문구만 수정했습니다. 동작 변경 없음.

| | 이전 | 이후(피그마) |
|---|---|---|
| 헤더 | 공연 삭제 | 공연 데이터 삭제 |
| 설명 | 공연을 삭제하시려면 정확한 공연명을 입력해 주세요. | 공연장과 연결된 공연 데이터를 삭제하려면 정확한 공연명을 입력해 주세요. |
| 주의 문구 | * 삭제 시 작성했던 공연 정보는 전부 사라지며 복구할 수 없어요. | * '직접 입력' 방식으로 추가한 공연 데이터와의 연결을 해제하는 경우, 해당 공연에 대한 데이터가 모두 사라지며 복구할 수 없어요. |

입력 placeholder("공연명을 입력해 주세요"), 버튼("삭제하기"), 입력 전 버튼 비활성 동작은 이미 피그마와 일치해 그대로 뒀습니다.

## 테스트

- `turbo type-check`, `turbo lint` (super-admin) 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)