### PR TITLE
feat(super-admin): 공연장 목록 카드에 업데이트 일시 표시

### DIFF
--- a/apps/super-admin/src/pages/HomePage/ConcertHallListTab.tsx
+++ b/apps/super-admin/src/pages/HomePage/ConcertHallListTab.tsx
@@ -2,6 +2,7 @@ import { PlusOutlined } from '@ant-design/icons';
 import { useSuperAdminConcertHallList } from '@boolti/api';
 import { useTheme } from '@emotion/react';
 import { Button, Card, Empty, Flex, Input, Pagination, Space, Tag, Typography } from 'antd';
+import { format } from 'date-fns';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -11,6 +12,10 @@ import { HREF } from '~/constants/routes';
 const { Search } = Input;
 
 const PAGE_SIZE = 20;
+
+// 공개 공연장 페이지는 'MM.DD'로 짧게 찍지만, 어드민은 시각까지 필요해서 포맷을 공유하지 않는다.
+const formatInformationUpdatedAt = (value?: string) =>
+  value ? format(new Date(value), 'yyyy.MM.dd HH:mm') : '-';
 
 const ConcertHallListTab = () => {
   const theme = useTheme();
@@ -60,7 +65,7 @@ const ConcertHallListTab = () => {
           <Empty description="등록된 공연장이 없어요." style={{ marginTop: 80 }} />
         ) : (
           <Flex gap="large" wrap="wrap" style={{ marginBottom: 20 }}>
-            {items.map(({ id, name, address, isVisible }) => (
+            {items.map(({ id, name, address, isVisible, informationUpdatedAt }) => (
               <Card
                 key={id}
                 style={{ width: 'calc(50% - 12px)', cursor: 'pointer' }}
@@ -101,6 +106,14 @@ const ConcertHallListTab = () => {
                         주소
                       </Typography>
                       <Typography.Text ellipsis>{address ?? '-'}</Typography.Text>
+                    </Space>
+                    <Space size="middle" style={{ marginTop: 4 }}>
+                      <Typography style={{ width: 60, color: theme.palette.grey.g60 }}>
+                        업데이트
+                      </Typography>
+                      <Typography.Text>
+                        {formatInformationUpdatedAt(informationUpdatedAt)}
+                      </Typography.Text>
                     </Space>
                   </Flex>
                 </Flex>

--- a/packages/api/src/types/superAdminConcertHall.ts
+++ b/packages/api/src/types/superAdminConcertHall.ts
@@ -22,6 +22,10 @@ export interface SuperAdminConcertHallItem {
   address?: string;
   /** 노출 여부 */
   isVisible: boolean;
+  /** 목록 썸네일 URL (등록된 이미지가 없으면 없음) */
+  thumbnailUrl?: string;
+  /** 정보 최종 업데이트 일시 (공연장 정보/대관/데이터 연결 중 최신, 수정 이력이 없으면 없음) */
+  informationUpdatedAt?: string;
 }
 
 export interface SuperAdminConcertHallListResponse {


### PR DESCRIPTION
## 배경

슈퍼어드민 홈 > 공연장 탭 목록에서 각 공연장의 마지막 업데이트 일시를 보여준다.
기준은 "공연장 정보 / 대관 / 데이터 연결 셋 중 최신"이고, 서버가 `informationUpdatedAt` 으로 내려준다.

서버 PR: team-fire-squirrel/boolti-api#393

## 변경

- `SuperAdminConcertHallItem` 타입에 `informationUpdatedAt` 추가
- 함께 `thumbnailUrl` 도 추가 — 서버 응답엔 이미 있는데 타입에 빠져 있었다 (렌더링은 이번 PR 범위 밖)
- `ConcertHallListTab` 카드의 "주소" 줄 아래에 "업데이트" 한 줄 추가

## 표시 규칙

- 포맷 `yyyy.MM.dd HH:mm`, 값이 없으면 `-`
- 공개 공연장 페이지(`apps/place`)는 `MM.DD` 로 짧게 찍으므로 **포맷 함수를 공유하지 않는다**
- 목록 정렬 UI 는 넣지 않는다 (요구사항 확인 결과 불필요)

## 검증

- `yarn type-check` 통과
- `yarn eslint` 변경 파일 통과

> 로컬에서는 node 20 이 필요하다 (`.nvmrc` v20.11.0). node 25 로는 Yarn PnP 로더가 EBADF 로 깨진다.