### PR TITLE
fix: 공연장 2차 QA 대응 및 공연 상세 → 공연장 프로필 연결

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -17485,6 +17485,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["preview", "workspace:apps/preview"],\
           ["@boolti/api", "workspace:packages/api"],\
+          ["@boolti/bridge", "workspace:packages/bridge"],\
           ["@boolti/eslint-config", "workspace:packages/config-eslint"],\
           ["@boolti/icon", "workspace:packages/icon"],\
           ["@boolti/typescript-config", "workspace:packages/config-typescript"],\

--- a/apps/admin/src/pages/PlaceSearchPage/index.tsx
+++ b/apps/admin/src/pages/PlaceSearchPage/index.tsx
@@ -145,10 +145,11 @@ const writeRecentKeywords = (keywords: string[]) => {
   window.localStorage.setItem(RECENT_KEYWORDS_STORAGE_KEY, JSON.stringify(keywords));
 };
 
+// 0은 미입력으로 간주해 노출하지 않는다.
 const formatSearchCapacity = (concertHall: ConcertHallSearchItem) => {
   const values = [];
-  if (concertHall.seatedCapacity != null) values.push(`좌석 ${concertHall.seatedCapacity}석`);
-  if (concertHall.standingCapacity != null) values.push(`스탠딩 ${concertHall.standingCapacity}명`);
+  if (concertHall.seatedCapacity) values.push(`좌석 ${concertHall.seatedCapacity}석`);
+  if (concertHall.standingCapacity) values.push(`스탠딩 ${concertHall.standingCapacity}명`);
   return values.length > 0 ? values.join(' · ') : '정보 없음';
 };
 

--- a/apps/place/src/App.tsx
+++ b/apps/place/src/App.tsx
@@ -13,17 +13,17 @@ import NotFoundPage from './pages/NotFoundPage';
 
 const router = createBrowserRouter([
   {
-    path: '/:concertHallId',
+    path: '/:shareCode',
     element: <ConcertHallPage />,
     errorElement: <ErrorPage />,
   },
   {
-    path: '/:concertHallId/home',
+    path: '/:shareCode/home',
     element: <ConcertHallTabPage tab="home" />,
     errorElement: <ErrorPage />,
   },
   {
-    path: '/:concertHallId/rental',
+    path: '/:shareCode/rental',
     element: <ConcertHallTabPage tab="rental" />,
     errorElement: <ErrorPage />,
   },

--- a/apps/place/src/pages/ConcertHallPage/index.tsx
+++ b/apps/place/src/pages/ConcertHallPage/index.tsx
@@ -1,4 +1,4 @@
-import { useConcertHallProfile } from '@boolti/api';
+import { useConcertHallProfileByShareCode } from '@boolti/api';
 import { ConcertHallProfile } from '@boolti/ui';
 import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
@@ -7,9 +7,9 @@ import Layout from '~/components/Layout';
 import { X_NCP_APIGW_API_KEY_ID } from '~/constants/ncp';
 
 const ConcertHallPage = () => {
-  const { concertHallId: idParam } = useParams<{ concertHallId: string }>();
-  const concertHallId = idParam && /^\d+$/.test(idParam) ? Number(idParam) : null;
-  const { data: profile } = useConcertHallProfile(concertHallId);
+  // URL은 내부 ID가 아니라 공유 코드를 쓴다. (예: /boolti)
+  const { shareCode } = useParams<{ shareCode: string }>();
+  const { data: profile } = useConcertHallProfileByShareCode(shareCode ?? null);
 
   useEffect(() => {
     if (profile?.name) {

--- a/apps/place/src/pages/ConcertHallTabPage/index.tsx
+++ b/apps/place/src/pages/ConcertHallTabPage/index.tsx
@@ -1,4 +1,4 @@
-import { useConcertHallProfile } from '@boolti/api';
+import { useConcertHallProfileByShareCode } from '@boolti/api';
 import { ConcertHallProfile } from '@boolti/ui';
 import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
@@ -13,9 +13,9 @@ interface Props {
 }
 
 const ConcertHallTabPage = ({ tab }: Props) => {
-  const { concertHallId: idParam } = useParams<{ concertHallId: string }>();
-  const concertHallId = idParam && /^\d+$/.test(idParam) ? Number(idParam) : null;
-  const { data: profile } = useConcertHallProfile(concertHallId);
+  // URL은 내부 ID가 아니라 공유 코드를 쓴다. (예: /boolti)
+  const { shareCode } = useParams<{ shareCode: string }>();
+  const { data: profile } = useConcertHallProfileByShareCode(shareCode ?? null);
 
   useEffect(() => {
     if (profile?.name) {

--- a/apps/preview/package.json
+++ b/apps/preview/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@boolti/api": "*",
+    "@boolti/bridge": "*",
     "@boolti/icon": "*",
     "@boolti/ui": "*",
     "@emotion/react": "^11.11.3",

--- a/apps/preview/src/pages/ShowInfoDetailPage/index.tsx
+++ b/apps/preview/src/pages/ShowInfoDetailPage/index.tsx
@@ -1,4 +1,5 @@
 import { ShowPreviewResponse } from '@boolti/api';
+import { navigateToPlaceDetail } from '@boolti/bridge';
 import { ShowInfoDetail } from '@boolti/ui';
 import { format } from 'date-fns';
 import { useLoaderData } from 'react-router-dom';
@@ -22,6 +23,7 @@ const ShowInfoDetailPage: React.FC = () => {
     detailAddress,
     latitude,
     longitude,
+    concertHallId,
   } = show;
 
   const callLinkClickHandler = () => {
@@ -30,6 +32,13 @@ const ShowInfoDetailPage: React.FC = () => {
 
   const messageLinkClickHandler = () => {
     location.href = `sms:${show.hostPhoneNumber}`;
+  };
+
+  // 공연장 프로필 화면은 앱이 담당하므로 브릿지로 넘긴다.
+  const placeProfileClickHandler = (hallId: number) => {
+    navigateToPlaceDetail({ concertHallId: hallId }).catch(() => {
+      // 앱이 응답하지 않아도 웹에서 할 수 있는 처리는 없다
+    });
   };
 
   return (
@@ -46,6 +55,7 @@ const ShowInfoDetailPage: React.FC = () => {
           hostName,
           latitude,
           longitude,
+          concertHallId,
         }}
         soldTicketCount={soldTicketCount}
         isAppWebview
@@ -53,6 +63,7 @@ const ShowInfoDetailPage: React.FC = () => {
         onClickMessageLink={messageLinkClickHandler}
         onClickCallLinkMobile={callLinkClickHandler}
         onClickMessageLinkMobile={messageLinkClickHandler}
+        onClickPlaceProfile={placeProfileClickHandler}
         naverMapClientId={X_NCP_APIGW_API_KEY_ID}
       />
     </Styled.Container>

--- a/apps/preview/src/pages/ShowInfoDetailPage/index.tsx
+++ b/apps/preview/src/pages/ShowInfoDetailPage/index.tsx
@@ -36,7 +36,7 @@ const ShowInfoDetailPage: React.FC = () => {
 
   // 공연장 프로필 화면은 앱이 담당하므로 브릿지로 넘긴다.
   const placeProfileClickHandler = (hallId: number) => {
-    navigateToPlaceDetail({ concertHallId: hallId }).catch(() => {
+    navigateToPlaceDetail({ placeId: hallId }).catch(() => {
       // 앱이 응답하지 않아도 웹에서 할 수 있는 처리는 없다
     });
   };

--- a/apps/preview/src/pages/ShowPreviewPage/index.tsx
+++ b/apps/preview/src/pages/ShowPreviewPage/index.tsx
@@ -1,4 +1,5 @@
 import { ShowCastTeamReadResponse, ShowPreviewResponse } from '@boolti/api';
+import { navigateToPlaceDetail } from '@boolti/bridge';
 import { Footer, ShowPreview, useDeviceByWidth, useDialog } from '@boolti/ui';
 import { format, setDefaultOptions } from 'date-fns';
 import { ko } from 'date-fns/locale';
@@ -90,7 +91,15 @@ const ShowPreviewPage = () => {
     hostPhoneNumber,
     latitude,
     longitude,
+    concertHallId,
   } = previewData;
+
+  // 공연장 프로필 화면은 앱이 담당하므로 브릿지로 넘긴다.
+  const placeProfileClickHandler = (hallId: number) => {
+    navigateToPlaceDetail({ concertHallId: hallId }).catch(() => {
+      // 앱이 응답하지 않아도 웹에서 할 수 있는 처리는 없다
+    });
+  };
 
   const shareShowPreviewLink = async () => {
     const text = getPreviewLink(id);
@@ -213,6 +222,7 @@ const ShowPreviewPage = () => {
               notice: text,
               hostName: hostName,
               hostPhoneNumber: hostPhoneNumber,
+              concertHallId,
             }}
             showCastTeams={showCastTeams.map(({ name, members }) => ({
               name,
@@ -235,6 +245,7 @@ const ShowPreviewPage = () => {
             onShareShowInfo={shareShowInfo}
             onCloseShareDropdown={shareDropdownCloseHandler}
             prioritizeFirstImage
+            onClickPlaceProfile={placeProfileClickHandler}
             naverMapClientId={X_NCP_APIGW_API_KEY_ID}
           />
           <Styled.FooterWrapper>

--- a/apps/preview/src/pages/ShowPreviewPage/index.tsx
+++ b/apps/preview/src/pages/ShowPreviewPage/index.tsx
@@ -96,7 +96,7 @@ const ShowPreviewPage = () => {
 
   // 공연장 프로필 화면은 앱이 담당하므로 브릿지로 넘긴다.
   const placeProfileClickHandler = (hallId: number) => {
-    navigateToPlaceDetail({ concertHallId: hallId }).catch(() => {
+    navigateToPlaceDetail({ placeId: hallId }).catch(() => {
       // 앱이 응답하지 않아도 웹에서 할 수 있는 처리는 없다
     });
   };

--- a/apps/super-admin/src/components/ConcertHallNavigation/ConcertHallNavigation.tsx
+++ b/apps/super-admin/src/components/ConcertHallNavigation/ConcertHallNavigation.tsx
@@ -1,15 +1,19 @@
 import { ArrowLeftIcon } from '@boolti/icon';
 import { useSuperAdminConcertHallDetail } from '@boolti/api';
-import { useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 
-import { HREF, PATH } from '~/constants/routes';
+import { HREF } from '~/constants/routes';
 import { ConcertHallDataIcon, ConcertHallInfoIcon, ConcertHallRentalIcon } from './icons';
 import Styled from './ConcertHallNavigation.styles';
 
 const ConcertHallNavigation = () => {
   const params = useParams<{ hallId: string }>();
+  const location = useLocation();
   const hallId = Number(params.hallId);
   const { data: concertHall } = useSuperAdminConcertHallDetail(hallId);
+
+  // 목록에서 진입했다면 그때의 검색어/페이지를 그대로 살려 돌아간다.
+  const from = (location.state as { from?: string } | null)?.from;
 
   const navigationItems = [
     { label: '공연장 정보', icon: <ConcertHallInfoIcon />, link: HREF.CONCERT_HALL_INFO(hallId) },
@@ -26,7 +30,7 @@ const ConcertHallNavigation = () => {
         <Styled.MenuItemList>
           {navigationItems.map((item) => (
             <Styled.MenuItem key={item.label}>
-              <Styled.MenuLink to={item.link}>
+              <Styled.MenuLink to={item.link} state={location.state}>
                 {item.icon}
                 {item.label}
               </Styled.MenuLink>
@@ -36,8 +40,8 @@ const ConcertHallNavigation = () => {
       </Styled.Navigation>
 
       <Styled.Footer>
-        <Styled.HomeButton to={PATH.INDEX}>
-          <ArrowLeftIcon /> <span style={{ paddingLeft: '8px' }}>슈퍼 어드민 홈</span>
+        <Styled.HomeButton to={from ?? HREF.CONCERT_HALL_LIST()}>
+          <ArrowLeftIcon /> <span style={{ paddingLeft: '8px' }}>공연장 홈</span>
         </Styled.HomeButton>
       </Styled.Footer>
     </Styled.Container>

--- a/apps/super-admin/src/components/Layout/Layout.tsx
+++ b/apps/super-admin/src/components/Layout/Layout.tsx
@@ -6,7 +6,7 @@ import ConcertHallNavigation from '../ConcertHallNavigation/ConcertHallNavigatio
 const Layout = ({ children }: { children: React.ReactNode }) => {
   const { pathname } = useLocation();
   const isShowRoute = pathname.startsWith('/show/');
-  const isConcertHallRoute = pathname.startsWith('/concert-hall/');
+  const isConcertHallRoute = pathname.startsWith('/place/');
 
   return (
     <>

--- a/apps/super-admin/src/constants/routes.ts
+++ b/apps/super-admin/src/constants/routes.ts
@@ -7,18 +7,20 @@ export const PATH = {
   PAYMENT: '/show/:showId/payment',
   ENTRANCE: '/show/:showId/entrance',
   SETTLEMENT: '/show/:showId/settlement',
-  CONCERT_HALL_INFO: '/concert-hall/:hallId/info',
-  CONCERT_HALL_RENTAL: '/concert-hall/:hallId/rental',
-  CONCERT_HALL_DATA: '/concert-hall/:hallId/data',
+  CONCERT_HALL_INFO: '/place/:hallId/info',
+  CONCERT_HALL_RENTAL: '/place/:hallId/rental',
+  CONCERT_HALL_DATA: '/place/:hallId/data',
 } as const;
 
 export const HREF = {
+  /** 홈의 공연장 탭. 공연장 페이지에서 목록으로 돌아갈 때 쓴다. */
+  CONCERT_HALL_LIST: () => `${PATH.INDEX}?tab=concert-halls`,
   INFO: (showId: string | number) => `/show/${showId}/info`,
   TICKET: (showId: string | number) => `/show/${showId}/ticket`,
   PAYMENT: (showId: string | number) => `/show/${showId}/payment`,
   ENTRANCE: (showId: string | number) => `/show/${showId}/entrance`,
   SETTLEMENT: (showId: string | number) => `/show/${showId}/settlement`,
-  CONCERT_HALL_INFO: (hallId: string | number) => `/concert-hall/${hallId}/info`,
-  CONCERT_HALL_RENTAL: (hallId: string | number) => `/concert-hall/${hallId}/rental`,
-  CONCERT_HALL_DATA: (hallId: string | number) => `/concert-hall/${hallId}/data`,
+  CONCERT_HALL_INFO: (hallId: string | number) => `/place/${hallId}/info`,
+  CONCERT_HALL_RENTAL: (hallId: string | number) => `/place/${hallId}/rental`,
+  CONCERT_HALL_DATA: (hallId: string | number) => `/place/${hallId}/data`,
 };

--- a/apps/super-admin/src/pages/ConcertHallRentalPage/index.tsx
+++ b/apps/super-admin/src/pages/ConcertHallRentalPage/index.tsx
@@ -101,8 +101,9 @@ const ConcertHallRentalPage = () => {
   const [hourlyFees, setHourlyFees] = useState<FeeRow[]>([{}]);
 
   // 공간 스펙
-  const [seatedCapacity, setSeatedCapacity] = useState<number>(0);
-  const [standingCapacity, setStandingCapacity] = useState<number>(0);
+  // 미입력과 0을 구분해야 한다. 0으로 초기화하면 입력하지 않은 공연장도 0명으로 저장된다.
+  const [seatedCapacity, setSeatedCapacity] = useState<number>();
+  const [standingCapacity, setStandingCapacity] = useState<number>();
   const [instrumentsText, setInstrumentsText] = useState('');
 
   // 유료 옵션 / 특이사항
@@ -117,8 +118,8 @@ const ConcertHallRentalPage = () => {
     setRentalTimeHours(rental.rentalTime?.rentalTimeHours ?? 0);
     setIsEngineerBreakIncluded(rental.rentalTime?.isEngineerBreakIncluded ?? false);
     setVatType(rental.vatType ?? 'NONE');
-    setSeatedCapacity(rental.capacity?.seatedCapacity ?? 0);
-    setStandingCapacity(rental.capacity?.standingCapacity ?? 0);
+    setSeatedCapacity(rental.capacity?.seatedCapacity);
+    setStandingCapacity(rental.capacity?.standingCapacity);
     setInstrumentsText(rental.instrumentsText ?? '');
     setSpecialNotes(rental.specialNotes?.length ? rental.specialNotes : ['']);
 
@@ -345,7 +346,7 @@ const ConcertHallRentalPage = () => {
                     min={0}
                     style={{ width: '100%' }}
                     value={seatedCapacity}
-                    onChange={(value) => setSeatedCapacity(value ?? 0)}
+                    onChange={(value) => setSeatedCapacity(value ?? undefined)}
                   />
                   <Typography.Text>명</Typography.Text>
                 </Flex>
@@ -358,7 +359,7 @@ const ConcertHallRentalPage = () => {
                     min={0}
                     style={{ width: '100%' }}
                     value={standingCapacity}
-                    onChange={(value) => setStandingCapacity(value ?? 0)}
+                    onChange={(value) => setStandingCapacity(value ?? undefined)}
                   />
                   <Typography.Text>명</Typography.Text>
                 </Flex>

--- a/apps/super-admin/src/pages/HomePage/ConcertHallListTab.tsx
+++ b/apps/super-admin/src/pages/HomePage/ConcertHallListTab.tsx
@@ -4,7 +4,7 @@ import { useTheme } from '@emotion/react';
 import { Button, Card, Empty, Flex, Input, Pagination, Space, Tag, Typography } from 'antd';
 import { format } from 'date-fns';
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 
 import ConcertHallCreateDialog from '~/components/ConcertHallCreateDialog/ConcertHallCreateDialog';
 import { HREF } from '~/constants/routes';
@@ -27,9 +27,12 @@ const formatUpdatedAt = (iso?: string | null) => {
 const ConcertHallListTab = () => {
   const theme = useTheme();
   const navigate = useNavigate();
-  const [searchText, setSearchText] = useState('');
-  const [keyword, setKeyword] = useState('');
-  const [currentPage, setCurrentPage] = useState(1);
+  const location = useLocation();
+  // 검색어와 페이지를 URL에 두어 공연장 페이지에서 돌아올 때 위치가 유지되도록 한다.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const keyword = searchParams.get('keyword') ?? '';
+  const currentPage = Number(searchParams.get('page')) || 1;
+  const [searchText, setSearchText] = useState(keyword);
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const { isLoading, data } = useSuperAdminConcertHallList(
     currentPage - 1,
@@ -38,9 +41,31 @@ const ConcertHallListTab = () => {
   );
   const { items = [], totalElements = 0, totalPages = 0 } = data ?? {};
 
+  const updateSearchParams = (next: { keyword?: string; page?: number }) => {
+    const params = new URLSearchParams(searchParams);
+    params.set('tab', 'concert-halls');
+
+    if (next.keyword !== undefined) {
+      if (next.keyword) {
+        params.set('keyword', next.keyword);
+      } else {
+        params.delete('keyword');
+      }
+    }
+
+    if (next.page !== undefined) {
+      if (next.page > 1) {
+        params.set('page', String(next.page));
+      } else {
+        params.delete('page');
+      }
+    }
+
+    setSearchParams(params);
+  };
+
   const onSearch = (value: string) => {
-    setKeyword(value.trim());
-    setCurrentPage(1);
+    updateSearchParams({ keyword: value.trim(), page: 1 });
   };
 
   if (isLoading) {
@@ -77,7 +102,9 @@ const ConcertHallListTab = () => {
                 key={id}
                 style={{ width: 'calc(50% - 12px)', cursor: 'pointer' }}
                 onClick={() => {
-                  navigate(HREF.CONCERT_HALL_INFO(id));
+                  navigate(HREF.CONCERT_HALL_INFO(id), {
+                    state: { from: `${location.pathname}${location.search}` },
+                  });
                 }}
               >
                 <Flex>
@@ -147,7 +174,7 @@ const ConcertHallListTab = () => {
           total={totalElements}
           showSizeChanger={false}
           onChange={(page) => {
-            setCurrentPage(page);
+            updateSearchParams({ page });
           }}
         />
       )}

--- a/packages/api/src/queries/index.ts
+++ b/packages/api/src/queries/index.ts
@@ -59,6 +59,7 @@ import useSuperAdminUserList from './useSuperAdminUserList';
 import useSuperAdminHostList from './useSuperAdminHostList';
 import useConcertHallSearch from './useConcertHallSearch';
 import useConcertHallProfile from './useConcertHallProfile';
+import useConcertHallProfileByShareCode from './useConcertHallProfileByShareCode';
 import useConcertHallImages from './useConcertHallImages';
 import useConcertHallSearchList from './useConcertHallSearchList';
 import useConcertHallRecommendedRegions from './useConcertHallRecommendedRegions';
@@ -136,6 +137,7 @@ export {
   useSuperAdminHostList,
   useConcertHallSearch,
   useConcertHallProfile,
+  useConcertHallProfileByShareCode,
   useConcertHallImages,
   useConcertHallSearchList,
   useConcertHallRecommendedRegions,

--- a/packages/api/src/queries/useConcertHallProfileByShareCode.ts
+++ b/packages/api/src/queries/useConcertHallProfileByShareCode.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { queryKeys } from '../queryKey';
+
+const useConcertHallProfileByShareCode = (shareCode: string | null) =>
+  useQuery({
+    ...queryKeys.concertHall.profileByShareCode(shareCode ?? ''),
+    enabled: Boolean(shareCode),
+  });
+
+export default useConcertHallProfileByShareCode;

--- a/packages/api/src/queryKey.ts
+++ b/packages/api/src/queryKey.ts
@@ -523,6 +523,12 @@ export const concertHallQueryKeys = createQueryKeys('concertHall', {
     queryFn: () =>
       fetcher.get<ConcertHallProfileResponse>(`web/papi/v1/concert-halls/${concertHallId}`),
   }),
+  /** 공유 코드로 조회. 응답은 id 조회와 동일하며 내부 id도 함께 내려온다. */
+  profileByShareCode: (shareCode: string) => ({
+    queryKey: [shareCode],
+    queryFn: () =>
+      fetcher.get<ConcertHallProfileResponse>(`web/papi/v1/concert-halls/share/${shareCode}`),
+  }),
   images: (concertHallId: number) => ({
     queryKey: [concertHallId],
     queryFn: () =>

--- a/packages/api/src/types/show.ts
+++ b/packages/api/src/types/show.ts
@@ -257,6 +257,8 @@ export interface ShowPreviewResponse {
   groupId: number;
   name: string;
   placeName: string;
+  /** 연결된 불티 공연장 ID. 미연결 시 null/undefined */
+  concertHallId?: number;
   date: string;
   runningTime: number;
   streetAddress: string;

--- a/packages/bridge/src/commands/index.ts
+++ b/packages/bridge/src/commands/index.ts
@@ -1,4 +1,5 @@
 export * from './navigateBack';
+export * from './navigateToPlaceDetail';
 export * from './navigateToShowDetail';
 export * from './requestToken';
 export * from './showToast';

--- a/packages/bridge/src/commands/navigateToPlaceDetail.ts
+++ b/packages/bridge/src/commands/navigateToPlaceDetail.ts
@@ -1,0 +1,11 @@
+import { sendCommand } from './sendCommand';
+
+export type NavigateToPlaceDetailRequestData = {
+  /** 공연장(플레이스) ID */
+  concertHallId: number;
+};
+
+/** 공연 상세의 공연장명을 눌렀을 때. 앱의 공연장 프로필 화면으로 연결한다. */
+export const navigateToPlaceDetail = (data: NavigateToPlaceDetailRequestData) => {
+  return sendCommand({ command: 'NAVIGATE_TO_PLACE_DETAIL', data });
+};

--- a/packages/bridge/src/commands/navigateToPlaceDetail.ts
+++ b/packages/bridge/src/commands/navigateToPlaceDetail.ts
@@ -2,7 +2,7 @@ import { sendCommand } from './sendCommand';
 
 export type NavigateToPlaceDetailRequestData = {
   /** 공연장(플레이스) ID */
-  concertHallId: number;
+  placeId: number;
 };
 
 /** 공연 상세의 공연장명을 눌렀을 때. 앱의 공연장 프로필 화면으로 연결한다. */

--- a/packages/bridge/src/types.ts
+++ b/packages/bridge/src/types.ts
@@ -1,5 +1,6 @@
 export type WebviewCommand =
   | 'NAVIGATE_TO_SHOW_DETAIL'
+  | 'NAVIGATE_TO_PLACE_DETAIL'
   | 'NAVIGATE_BACK'
   | 'REQUEST_TOKEN'
   | 'SHOW_TOAST'

--- a/packages/ui/src/components/ShowPreview/ShowInfoDetail.tsx
+++ b/packages/ui/src/components/ShowPreview/ShowInfoDetail.tsx
@@ -1,7 +1,14 @@
 import { lazy, Suspense, useRef, useState, useEffect } from 'react';
 import { useSwiper } from 'swiper/react';
 import { showToast, checkIsWebView, TOAST_DURATIONS } from '@boolti/bridge';
-import { CallIcon, ChevronDownIcon, ChevronUpIcon, MessageIcon, TicketIcon } from '@boolti/icon';
+import {
+  CallIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
+  ChevronUpIcon,
+  MessageIcon,
+  TicketIcon,
+} from '@boolti/icon';
 
 import Styled from './ShowPreview.styles';
 import ShowNoticeHtmlContent from './ShowNoticeHtmlContent';
@@ -21,6 +28,8 @@ interface Props {
     detailAddress: string;
     latitude?: number;
     longitude?: number;
+    /** 연결된 불티 공연장 ID. 값이 있고 onClickPlaceProfile이 있을 때만 프로필로 이동할 수 있다. */
+    concertHallId?: number;
   };
   soldTicketCount?: number;
   isAppWebview?: boolean;
@@ -29,6 +38,8 @@ interface Props {
   onClickCallLinkMobile?: () => void;
   onClickMessageLinkMobile?: () => void;
   onClickViewNotice?: () => void;
+  /** 공연장 프로필로 이동. 넘기지 않으면 공연장명은 텍스트로만 노출된다. */
+  onClickPlaceProfile?: (concertHallId: number) => void;
   naverMapClientId?: string;
 }
 
@@ -44,6 +55,7 @@ const ShowInfoDetail = ({
     placeName,
     streetAddress,
     detailAddress,
+    concertHallId,
   },
   soldTicketCount,
   isAppWebview = false,
@@ -52,6 +64,7 @@ const ShowInfoDetail = ({
   onClickCallLinkMobile,
   onClickMessageLinkMobile,
   onClickViewNotice,
+  onClickPlaceProfile,
   naverMapClientId,
 }: Props) => {
   const showNoticeRef = useRef<HTMLDivElement>(null);
@@ -129,7 +142,17 @@ const ShowInfoDetail = ({
         <Styled.ShowInfoTitleContainer>
           <Styled.ShowInfoTitle>위치</Styled.ShowInfoTitle>
         </Styled.ShowInfoTitleContainer>
-        <Styled.ShowInfoSubtitle>{placeName}</Styled.ShowInfoSubtitle>
+        {concertHallId && onClickPlaceProfile ? (
+          <Styled.ShowInfoSubtitleButton
+            type="button"
+            onClick={() => onClickPlaceProfile(concertHallId)}
+          >
+            {placeName}
+            <ChevronRightIcon />
+          </Styled.ShowInfoSubtitleButton>
+        ) : (
+          <Styled.ShowInfoSubtitle>{placeName}</Styled.ShowInfoSubtitle>
+        )}
         <Styled.ShowInfoDescription>
           <Styled.ShowInfoDescriptionText>
             {`${streetAddress} / ${detailAddress} ・ `}

--- a/packages/ui/src/components/ShowPreview/ShowPreview.styles.ts
+++ b/packages/ui/src/components/ShowPreview/ShowPreview.styles.ts
@@ -131,6 +131,26 @@ const ShowHeaderInfoItem = styled.div`
   color: ${({ theme }) => theme.palette.mobile.grey.g30};
 `;
 
+/** 공연장 프로필이 연결된 경우의 헤더 공연장명. 아이콘·이름·화살표 전체가 터치 영역이다. */
+const ShowHeaderPlaceButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  ${({ theme }) => theme.typo.b3};
+  color: ${({ theme }) => theme.palette.mobile.grey.g30};
+  text-align: left;
+  cursor: pointer;
+  transition: opacity 0.2s;
+
+  &:active {
+    opacity: 0.7;
+  }
+
+  svg {
+    flex-shrink: 0;
+  }
+`;
+
 const ShowPreviewContent = styled.div`
   padding: 20px 20px 0;
   position: relative;
@@ -484,6 +504,7 @@ export default {
   ShowName,
   ShowHeaderInfoList,
   ShowHeaderInfoItem,
+  ShowHeaderPlaceButton,
   ShowPreviewContent,
   ShowPreviewTicketPeriod,
   ShowPreviewTicketPeriodInfo,

--- a/packages/ui/src/components/ShowPreview/ShowPreview.styles.ts
+++ b/packages/ui/src/components/ShowPreview/ShowPreview.styles.ts
@@ -250,6 +250,27 @@ const ShowInfoSubtitle = styled.h4`
   margin-bottom: 4px;
 `;
 
+/** 공연장 프로필이 연결된 경우의 공연장명. 이름과 화살표 전체가 터치 영역이다. */
+const ShowInfoSubtitleButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 4px;
+  ${({ theme }) => theme.typo.b3};
+  color: ${({ theme }) => theme.palette.mobile.grey.g10};
+  text-align: left;
+  cursor: pointer;
+  transition: opacity 0.2s;
+
+  &:active {
+    opacity: 0.7;
+  }
+
+  svg {
+    flex-shrink: 0;
+  }
+`;
+
 const ShowInfoDescription = styled.div<ShowInfoDescriptionProps>`
   ${({ theme }) => theme.typo.b3};
   color: ${({ theme }) => theme.palette.mobile.grey.g30};
@@ -475,6 +496,7 @@ export default {
   ShowInfoTitle,
   ShowInfoMoreButton,
   ShowInfoSubtitle,
+  ShowInfoSubtitleButton,
   ShowInfoDescription,
   ShowInfoDescriptionText,
   ShowInfoDescriptionButton,

--- a/packages/ui/src/components/ShowPreview/index.tsx
+++ b/packages/ui/src/components/ShowPreview/index.tsx
@@ -41,6 +41,8 @@ interface ShowPreviewProps {
     hostPhoneNumber: string;
     latitude?: number;
     longitude?: number;
+    /** 연결된 불티 공연장 ID */
+    concertHallId?: number;
   };
   showCastTeams: Array<{
     name: string;
@@ -62,6 +64,8 @@ interface ShowPreviewProps {
   onShareShowInfo?: () => void;
   onCloseShareDropdown?: () => void;
   prioritizeFirstImage?: boolean;
+  /** 공연장 프로필로 이동. 넘기지 않으면 공연장명은 텍스트로만 노출된다. */
+  onClickPlaceProfile?: (concertHallId: number) => void;
   naverMapClientId?: string;
 }
 
@@ -79,6 +83,7 @@ const ShowPreview = ({
   onShareShowInfo,
   onCloseShareDropdown,
   prioritizeFirstImage = false,
+  onClickPlaceProfile,
   naverMapClientId,
 }: ShowPreviewProps) => {
   const { images, name, date, startTime, runningTime, placeName } = show;
@@ -220,6 +225,7 @@ const ShowPreview = ({
                   onClickMessageLink={onClickLink}
                   onClickCallLinkMobile={onClickLinkMobile}
                   onClickMessageLinkMobile={onClickLinkMobile}
+                  onClickPlaceProfile={onClickPlaceProfile}
                   naverMapClientId={naverMapClientId}
                 />
               ),

--- a/packages/ui/src/components/ShowPreview/index.tsx
+++ b/packages/ui/src/components/ShowPreview/index.tsx
@@ -5,7 +5,13 @@ import type { ImgHTMLAttributes } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { Pagination } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
-import { BooltiDark, ClockMobileIcon, MapMarkerIcon, ShareIcon } from '@boolti/icon';
+import {
+  BooltiDark,
+  ChevronRightIcon,
+  ClockMobileIcon,
+  MapMarkerIcon,
+  ShareIcon,
+} from '@boolti/icon';
 
 import Styled from './ShowPreview.styles';
 import Tab from '../Tab';
@@ -86,7 +92,7 @@ const ShowPreview = ({
   onClickPlaceProfile,
   naverMapClientId,
 }: ShowPreviewProps) => {
-  const { images, name, date, startTime, runningTime, placeName } = show;
+  const { images, name, date, startTime, runningTime, placeName, concertHallId } = show;
 
   const [noticeOpen, setNoticeOpen] = useState<boolean>(false);
   const containerScrollTop = useRef<number | null>(null);
@@ -207,10 +213,21 @@ const ShowPreview = ({
             </span>
             <Styled.ShowInfoDescriptionBadge>{runningTime}분</Styled.ShowInfoDescriptionBadge>
           </Styled.ShowHeaderInfoItem>
-          <Styled.ShowHeaderInfoItem>
-            <MapMarkerIcon />
-            <span>{placeName}</span>
-          </Styled.ShowHeaderInfoItem>
+          {concertHallId && onClickPlaceProfile ? (
+            <Styled.ShowHeaderPlaceButton
+              type="button"
+              onClick={() => onClickPlaceProfile(concertHallId)}
+            >
+              <MapMarkerIcon />
+              <span>{placeName}</span>
+              <ChevronRightIcon />
+            </Styled.ShowHeaderPlaceButton>
+          ) : (
+            <Styled.ShowHeaderInfoItem>
+              <MapMarkerIcon />
+              <span>{placeName}</span>
+            </Styled.ShowHeaderInfoItem>
+          )}
         </Styled.ShowHeaderInfoList>
       </Styled.ShowPreviewHeader>
       <Styled.ShowPreviewContent>

--- a/packages/ui/src/features/ConcertHallProfile/utils/format.ts
+++ b/packages/ui/src/features/ConcertHallProfile/utils/format.ts
@@ -17,14 +17,15 @@ export const formatUpdatedAt = (iso?: string) => {
   return `${date.getFullYear()}.${month}.${day}`;
 };
 
+// 0은 미입력으로 간주해 노출하지 않는다. (어드민도 "1명 이상 입력 시 노출" 기준)
 export const formatCapacity = (capacity?: ConcertHallCapacity) => {
   const parts: string[] = [];
 
-  if (capacity?.seatedCapacity != null) {
+  if (capacity?.seatedCapacity) {
     parts.push(`좌석 ${capacity.seatedCapacity.toLocaleString()}석`);
   }
 
-  if (capacity?.standingCapacity != null) {
+  if (capacity?.standingCapacity) {
     parts.push(`스탠딩 ${capacity.standingCapacity.toLocaleString()}명`);
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13163,6 +13163,7 @@ __metadata:
   resolution: "preview@workspace:apps/preview"
   dependencies:
     "@boolti/api": "npm:*"
+    "@boolti/bridge": "npm:*"
     "@boolti/eslint-config": "npm:*"
     "@boolti/icon": "npm:*"
     "@boolti/typescript-config": "npm:*"


### PR DESCRIPTION
## 개요

공연장 2차 QA 4건과, 공연 상세에서 공연장 프로필로 이동하는 기능을 함께 작업했습니다.

## 2차 QA

### ① 공연장 프로필 URL을 공유 코드로

```
전: https://place.boolti.in/76        (내부 ID)
후: https://place.boolti.in/boolti    (공유 코드)
```

서버에 공유 코드 조회 API(`GET /web/papi/v1/concert-halls/share/{shareCode}`)가 추가되어 연동했습니다.

응답이 ID 조회와 동일한 형태이고 내부 `id`도 함께 내려와서, 사진 목록 등 하위 조회는 기존 로직을 그대로 씁니다. 어드민은 내부 ID로 조회하므로 기존 `useConcertHallProfile`은 두고 훅을 따로 추가했습니다.

> **숫자 URL은 더 이상 열리지 않습니다.** 공유 코드에 숫자가 허용되어 ID와 구분할 수 없기 때문입니다. 앱이 `/{id}`로 딥링크한다면 앱 수정이 필요합니다. (어드민 공유 기능은 이미 공유 코드를 쓰고 있었습니다.)

### ② 수용 인원이 0으로 저장되던 문제

상태 초기값이 `0`이라 입력하지 않은 공연장도 저장 시 `capacity: { seatedCapacity: 0, standingCapacity: 0 }`이 나가고 있었습니다. 초기값을 `undefined`로 바꿔 미입력과 0을 구분합니다.

이미 0으로 저장된 데이터가 있어 노출 쪽도 막았습니다. 어드민 문구("1명 이상 입력 시 사용자 화면에 노출돼요")와 같은 기준으로 0은 미입력으로 처리하며, 공연장 프로필과 어드민 검색 리스트 양쪽에 적용했습니다.

### ③ 어드민 주소를 place로 통일

`/concert-hall/:hallId/*` → `/place/:hallId/*`

### ④ 사이드 네비게이션 하단 버튼

`[← 슈퍼 어드민 홈]` → `[← 공연장 홈]`, 이동 대상도 공연 목록이 아닌 공연장 목록으로 바꿨습니다.

"기존에 접근했던 페이지 위치를 살려달라"는 요청에 맞춰, 목록의 검색어와 페이지를 URL 쿼리에 두고 공연장 진입 시 그 위치를 state로 넘깁니다. 공연장 정보 ↔ 대관 정보 탭을 오가도 유지되며, 딥링크로 바로 진입한 경우엔 `/?tab=concert-halls`로 폴백합니다.

## 공연 상세 → 공연장 프로필 연결

공연 응답의 `concertHallId`가 있으면 공연장명 옆에 화살표를 노출하고, 누르면 공연장 프로필로 이동합니다. 연결된 공연장이 없으면 기존처럼 텍스트로만 노출합니다.

진입점은 **상단 헤더**와 **위치 섹션** 두 곳이며, 터치 영역은 아이콘·이름·화살표 전체입니다.

프로필 화면은 앱이 담당하므로 브릿지 커맨드를 추가했습니다.

```json
{ "command": "NAVIGATE_TO_PLACE_DETAIL", "data": { "placeId": 72 } }
```

필드명은 기존 `NAVIGATE_TO_SHOW_DETAIL`(`showId`)과 같은 패턴으로 맞췄습니다.

> **앱에서 핸들러 추가가 필요합니다.** 앱이 받기 전까지 이 동작은 무반응입니다.

부수 변경: `ShowPreviewResponse`에 `concertHallId` 추가(서버는 이미 내려주고 있었습니다), preview 앱에 `@boolti/bridge` 의존성 추가.

## 검증

- place / admin / super-admin / preview 4개 앱 type-check, 프로덕션 빌드, lint 통과
- admin 테스트 16 실패 / 207 통과 — develop 기준선과 동일 (남은 실패는 기존 이슈)
- 브라우저 확인
  - 공유 코드 URL 3종(`/boolti`, `/boolti/home`, `/boolti/rental`)과 갤러리 이미지 조회
  - 잘못된 공유 코드 → 에러 화면 (기존에는 빈 화면으로 멈췄습니다)
  - 수용 인원 입력을 비웠을 때 0으로 되돌아가지 않음 / 0 저장된 공연장은 프로필에서 미노출
  - `/place/76/info` 라우트, 공연장 홈 버튼과 목록 위치 복원
  - 공연 상세 헤더·위치 양쪽의 화살표 노출(show 101) 및 미노출(show 50)

## 확인 필요

- **수용 인원 저장 왕복은 검증하지 못했습니다.** 입력을 비우면 `capacity: {}`가 나가는데, 서버가 이를 "값 없음으로 갱신"으로 처리하는지 "변경 없음"으로 처리하는지 확인이 필요합니다. 후자라면 이미 0으로 저장된 공연장은 값을 지울 수 없습니다.
- **어드민 공연 등록/수정 미리보기**에는 공연장 프로필 이동을 적용하지 않았습니다. 수정 중에는 링크가 없어도 된다는 의견에 따라 화살표 없이 텍스트로만 노출됩니다.
- **웹(비 웹뷰)에서는 공연장명을 눌러도 아무 동작이 없습니다.** 공연 상세가 앱 웹뷰 전용이면 현재 상태로 두면 되고, 웹에서도 열린다면 `place.boolti.in/{shareCode}`로 여는 폴백이 필요합니다.

## 로컬 실행

`apps/place/.env.local`의 `VITE_BASE_API_URL`을 `/dev-api`로 설정해야 place 앱이 뜹니다. (이전 PR에서 추가한 dev 프록시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfvcniqF4D14j9zKFsii3F